### PR TITLE
feat(commercetools): add support for pay later payment method

### DIFF
--- a/examples/node/src/utils.ts
+++ b/examples/node/src/utils.ts
@@ -48,8 +48,16 @@ export function getCommercetoolsTestConfiguration() {
         },
         isPunchOut: false,
         description: 'Stripe payment gateway',
-
       },
+      {
+        identifier: {
+          method: 'paylater',
+          name: 'Pay Later',
+          paymentProcessor: 'paylater'
+        },
+        description: 'Payment that is handled at a later point',
+        isPunchOut: false
+      }
     ],
     facetFieldsForSearch: (process.env['CTP_FACET_FIELDS_FOR_SEARCH'] || '').split(',') || ['category.id' ]
   } satisfies CommercetoolsConfiguration;

--- a/providers/commercetools/src/core/initialize.ts
+++ b/providers/commercetools/src/core/initialize.ts
@@ -123,7 +123,7 @@ export function withCommercetoolsCapabilities<
     }
 
     if (caps.order) {
-        client.store = new CommercetoolsOrderProvider(
+        client.order = new CommercetoolsOrderProvider(
         config,
         cache,
         context,

--- a/providers/commercetools/src/providers/checkout.provider.ts
+++ b/providers/commercetools/src/providers/checkout.provider.ts
@@ -721,6 +721,15 @@ export class CommercetoolsCheckoutProvider extends CheckoutProvider {
     // and it should be paid for
     if (paymentInstructions.length === 0) return false;
 
+    // TODO: consider whether this should happen server-side. 
+    // technically it might make sense to say that PayLater isn't marked as authorized, since authorization is external
+    // but alternatively the CT project should immediately mark it as authorized internally in a hook
+    const payLater = paymentInstructions.filter((pi) => pi.paymentMethod.method === 'paylater');
+
+    if (payLater.length > 0) {
+      return true;
+    }
+
     const authorizedPayments = paymentInstructions
       .filter((pi) => pi.status === 'authorized')
       .map((x) => x.amount.value)


### PR DESCRIPTION
Do not merge yet, this is just to see that it works. It seems that we have two options here:

1. Say that this really is a type of payment that IS indeed pending, and that checkout should be allowed with it (which is what is done here), and that some process may or may not subsequently mark it as authorized. This seems a bit iffy.
2. Treat it as any other payment, and have a hook in the CT base for paylater that just authorizes it. This could in principle be a conceptual substitute for "check that the customers line of credit is valid" or similar.

I'm leaning towards (2), and I'll take a look at putting that into the base composable (not as a credit check, but as a hook for accepting any paylater instruction).