### PR TITLE
refactor(hcl): remove fetchXxx wrappers, public methods call client d…

### DIFF
--- a/packages/hcl/src/capabilities/cart.capability.ts
+++ b/packages/hcl/src/capabilities/cart.capability.ts
@@ -73,15 +73,27 @@ export class HclCartCapability<
     this.factory = factory;
   }
 
+  protected setPendingOrderUrl(orderId: string): string {
+    return `${this.client.transactionBaseUrl}/cart/${encodeURIComponent(orderId)}/set_pending_order`;
+  }
+
+  protected setPendingOrderPayload(orderId: string): { orderId: string } {
+    return { orderId };
+  }
+
   /**
    * Set the specified order as the current pending (@self) order.
    * After this call, @self endpoints will operate on that orderId.
    */
   protected async fetchSetPendingOrder(orderId: string): Promise<void> {
     await this.client.callPost<unknown>(
-      `${this.client.transactionBaseUrl}/cart/${encodeURIComponent(orderId)}/set_pending_order`,
-      { orderId },
+      this.setPendingOrderUrl(orderId),
+      this.setPendingOrderPayload(orderId),
     );
+  }
+
+  protected wcsOrderUrl(orderId: string): string {
+    return `${this.client.transactionBaseUrl}/order/${encodeURIComponent(orderId)}`;
   }
 
   /**
@@ -91,12 +103,16 @@ export class HclCartCapability<
    */
   protected async fetchWcsOrder(orderId: string): Promise<HclWcsCartResponse> {
     const data = await this.client.callGet<HclWcsCartResponse>(
-      `${this.client.transactionBaseUrl}/order/${encodeURIComponent(orderId)}`,
+      this.wcsOrderUrl(orderId),
       undefined,
       { allowUndefined: true },
     );
     if (!data) throw new HclCartNotFoundError();
     return data;
+  }
+
+  protected cartUrl(): string {
+    return `${this.client.transactionBaseUrl}/cart/@self`;
   }
 
   /**
@@ -110,7 +126,7 @@ export class HclCartCapability<
       return this.fetchWcsOrder(orderId);
     }
     const data = await this.client.callGet<HclWcsCartResponse>(
-      `${this.client.transactionBaseUrl}/cart/@self`,
+      this.cartUrl(),
       undefined,
       { allowUndefined: true },
     );
@@ -126,142 +142,97 @@ export class HclCartCapability<
     return this.factory.parseCart(this.context, data);
   }
 
-  /** Add a SKU to the cart (creates the cart if it does not yet exist).
-   * Pass `currency` to force the price calculation into that currency
-   * (used when copying items to a new order during changeCurrency).
-   */
-  protected async fetchAddOrderItem(
-    partNumber: string,
-    quantity: number,
-    currency?: string,
-  ): Promise<HclWcsOrderItemUpdateResponse> {
+  protected addOrderItemUrl(currency?: string): string {
     const qs = currency ? `?currency=${encodeURIComponent(currency)}` : '';
-    return this.client.callPost<HclWcsOrderItemUpdateResponse>(
-      `${this.client.transactionBaseUrl}/cart${qs}`,
-      {
-        orderItem: [{ partNumber, quantity: String(quantity) }],
-        x_calculateOrder: '1',
-        x_calculationUsage: '-1,-2,-3,-4,-5,-6,-7',
-      },
-    );
+    return `${this.client.transactionBaseUrl}/cart${qs}`;
   }
 
-  /** Update the quantity of an existing cart item. */
-  protected async fetchUpdateOrderItem(
+  protected addOrderItemPayload(partNumber: string, quantity: number): object {
+    return {
+      orderItem: [{ partNumber, quantity: String(quantity) }],
+      x_calculateOrder: '1',
+      x_calculationUsage: '-1,-2,-3,-4,-5,-6,-7',
+    };
+  }
+
+  protected updateOrderItemUrl(): string {
+    return `${this.client.transactionBaseUrl}/cart/@self/update_order_item`;
+  }
+
+  protected updateOrderItemPayload(
     orderItemId: string,
     quantity: number,
-  ): Promise<HclWcsOrderItemUpdateResponse> {
-    return this.client.callPut<HclWcsOrderItemUpdateResponse>(
-      `${this.client.transactionBaseUrl}/cart/@self/update_order_item`,
-      {
-        orderItem: [{ orderItemId, quantity: String(quantity) }],
-        x_calculateOrder: '1',
-        x_calculationUsage: '-1,-2,-3,-4,-5,-6,-7',
-      },
-    );
+  ): object {
+    return {
+      orderItem: [{ orderItemId, quantity: String(quantity) }],
+      x_calculateOrder: '1',
+      x_calculationUsage: '-1,-2,-3,-4,-5,-6,-7',
+    };
   }
 
-  /** Remove a single item from the cart. */
-  protected async fetchDeleteOrderItem(orderItemId: string): Promise<void> {
-    await this.client.callPut<void>(
-      `${this.client.transactionBaseUrl}/cart/@self/delete_order_item`,
-      {
-        orderItemId,
-        x_calculateOrder: '1',
-        x_calculationUsage: '-1,-2,-3,-4,-5,-6,-7',
-      },
-    );
+  protected deleteOrderItemUrl(): string {
+    return `${this.client.transactionBaseUrl}/cart/@self/delete_order_item`;
   }
 
-  /**
-   * Delete (cancel) the specified order, or the current pending order.
-   * If orderId is provided, cancels that specific order via its own endpoint.
-   */
-  protected async fetchDeleteCart(orderId?: string): Promise<void> {
-    if (orderId) {
-      return this.client.callDelete(
-        `${this.client.transactionBaseUrl}/cart/${encodeURIComponent(orderId)}/cancel_order`,
-        { ignore404: true },
-      );
-    }
-    return this.client.callDelete(
-      `${this.client.transactionBaseUrl}/cart/@self`,
-      { ignore404: true },
-    );
+  protected deleteOrderItemPayload(orderItemId: string): object {
+    return {
+      orderItemId,
+      x_calculateOrder: '1',
+      x_calculationUsage: '-1,-2,-3,-4,-5,-6,-7',
+    };
   }
 
-  /**
-   * Fetch a list of all pending orders from the Order API.
-   * Calls GET /order/byStatus/P — returns all P-status orders for the current user.
-   */
-  protected async fetchWcsOrderList(): Promise<HclWcsOrderListResponse> {
-    const data = await this.client.callGet<HclWcsOrderListResponse>(
-      `${this.client.transactionBaseUrl}/order/byStatus/P`,
-      undefined,
-      { allowUndefined: true },
-    );
-    return data ?? { Order: [] };
+  protected deleteCartUrl(orderId?: string): string {
+    return orderId
+      ? `${this.client.transactionBaseUrl}/cart/${encodeURIComponent(orderId)}/cancel_order`
+      : `${this.client.transactionBaseUrl}/cart/@self`;
   }
 
-  /**
-   * Create a new order in WCS with an optional description/name and currency.
-   * Calls POST /cart/create_order?description={name}[&currency={currency}]
-   */
-  protected async fetchCreateOrder(
+  protected orderListUrl(): string {
+    return `${this.client.transactionBaseUrl}/order/byStatus/P`;
+  }
+
+  protected createOrderUrl(): string {
+    return `${this.client.transactionBaseUrl}/cart/create_order`;
+  }
+
+  protected createOrderParams(
     description?: string,
     currency?: string,
-  ): Promise<HclWcsCreateOrderResponse> {
+  ): URLSearchParams {
     const params = new URLSearchParams();
     // description is mandatory for WCS create_order — default to empty string.
     params.set('description', description ?? '');
     if (currency) params.set('currency', currency);
-    return this.client.callPost<HclWcsCreateOrderResponse>(
-      `${this.client.transactionBaseUrl}/cart/create_order?${params.toString()}`,
-      {},
-    );
+    return params;
   }
 
-  /**
-   * Persist the cart description (name) to WCS via the update_order_item
-   * endpoint. Must call fetchSetPendingOrder first if targeting a
-   * non-current order.
-   *
-   */
-  protected async fetchUpdateOrderDescription(
+  protected updateOrderDescriptionUrl(): string {
+    return `${this.client.transactionBaseUrl}/cart/@self/update_order_item`;
+  }
+
+  protected updateOrderDescriptionPayload(
     description: string,
-  ): Promise<void> {
-    // WCS update_order_item requires an orderItem array in the body — include
-    // the current items so the endpoint does not return HTTP 500.
-    const cart = await this.fetchWcsCart();
-    const orderItem = (cart.orderItem ?? []).map((item) => ({
-      orderItemId: item.orderItemId,
-      quantity: item.quantity,
-    }));
-    await this.client.callPut<unknown>(
-      `${this.client.transactionBaseUrl}/cart/@self/update_order_item`,
-      {
-        orderDescription: description,
-        orderItem,
-        x_calculateOrder: '1',
-        x_calculationUsage: '-1,-2,-3,-4,-5,-6,-7',
-      },
-    );
+    orderItem: Array<{ orderItemId: string; quantity: string }>,
+  ): object {
+    return {
+      orderDescription: description,
+      orderItem,
+      x_calculateOrder: '1',
+      x_calculationUsage: '-1,-2,-3,-4,-5,-6,-7',
+    };
   }
 
-  /** Apply a promotion/coupon code to the cart. */
-  protected async fetchAddPromotionCode(code: string): Promise<void> {
-    await this.client.callPost<void>(
-      `${this.client.transactionBaseUrl}/cart/@self/assigned_promotion_code`,
-      { promoCode: code },
-    );
+  protected addPromotionCodeUrl(): string {
+    return `${this.client.transactionBaseUrl}/cart/@self/assigned_promotion_code`;
   }
 
-  /** Remove a promotion/coupon code from the cart. */
-  protected async fetchRemovePromotionCode(code: string): Promise<void> {
-    return this.client.callDelete(
-      `${this.client.transactionBaseUrl}/cart/@self/assigned_promotion_code/${encodeURIComponent(code)}`,
-      { ignore404: true },
-    );
+  protected addPromotionCodePayload(code: string): { promoCode: string } {
+    return { promoCode: code };
+  }
+
+  protected removePromotionCodeUrl(code: string): string {
+    return `${this.client.transactionBaseUrl}/cart/@self/assigned_promotion_code/${encodeURIComponent(code)}`;
   }
 
   @Reactionary({
@@ -317,7 +288,10 @@ export class HclCartCapability<
     if (payload.cart.key) {
       await this.fetchSetPendingOrder(payload.cart.key);
     }
-    await this.fetchAddOrderItem(payload.variant.sku, payload.quantity);
+    await this.client.callPost<HclWcsOrderItemUpdateResponse>(
+      this.addOrderItemUrl(),
+      this.addOrderItemPayload(payload.variant.sku, payload.quantity),
+    );
     return success(await this.fetchCart(payload.cart.key || undefined));
   }
 
@@ -332,7 +306,10 @@ export class HclCartCapability<
     if (payload.cart.key) {
       await this.fetchSetPendingOrder(payload.cart.key);
     }
-    await this.fetchDeleteOrderItem(payload.item.key);
+    await this.client.callPut<void>(
+      this.deleteOrderItemUrl(),
+      this.deleteOrderItemPayload(payload.item.key),
+    );
     return success(await this.fetchCart(payload.cart.key || undefined));
   }
 
@@ -352,7 +329,10 @@ export class HclCartCapability<
     if (payload.cart.key) {
       await this.fetchSetPendingOrder(payload.cart.key);
     }
-    await this.fetchUpdateOrderItem(payload.item.key, payload.quantity);
+    await this.client.callPut<HclWcsOrderItemUpdateResponse>(
+      this.updateOrderItemUrl(),
+      this.updateOrderItemPayload(payload.item.key, payload.quantity),
+    );
     return success(await this.fetchCart(payload.cart.key || undefined));
   }
 
@@ -370,7 +350,12 @@ export class HclCartCapability<
     >
   > {
     debug('listCarts');
-    const orderList = await this.fetchWcsOrderList();
+    const data = await this.client.callGet<HclWcsOrderListResponse>(
+      this.orderListUrl(),
+      undefined,
+      { allowUndefined: true },
+    );
+    const orderList = data ?? { Order: [] };
     return success(
       this.factory.parseCartPaginatedSearchResult(
         this.context,
@@ -389,7 +374,10 @@ export class HclCartCapability<
   ): Promise<Result<CartFactoryCartOutput<TFactory>>> {
     debug('createCart name=%s', payload.name);
     // Create the order in WCS with the name as description so it persists.
-    const result = await this.fetchCreateOrder(payload.name || undefined);
+    const result = await this.client.callPost<HclWcsCreateOrderResponse>(
+      `${this.createOrderUrl()}?${this.createOrderParams(payload.name || undefined).toString()}`,
+      {},
+    );
     // Also store in session so the current request can read back the name.
     if (payload.name) {
       this.context.session['hcl.cartName'] = payload.name;
@@ -404,7 +392,12 @@ export class HclCartCapability<
     payload: CartMutationDeleteCart,
   ): Promise<Result<void>> {
     debug('deleteCart %s', payload.cart.key);
-    await this.fetchDeleteCart(payload.cart.key || undefined);
+    await this.client.callDelete(
+      this.deleteCartUrl(payload.cart.key || undefined),
+      {
+        ignore404: true,
+      },
+    );
     return success(undefined);
   }
 
@@ -420,7 +413,17 @@ export class HclCartCapability<
       await this.fetchSetPendingOrder(payload.cart.key);
     }
     // Persist the new name to HCL as the order description.
-    await this.fetchUpdateOrderDescription(payload.newName);
+    const wcsCart = await this.fetchWcsCart();
+    const orderItem = (wcsCart.orderItem ?? []).map((item) => ({
+      orderItemId: item.orderItemId,
+      quantity: item.quantity,
+    }));
+    await this.client.callPut<unknown>(
+      this.updateOrderDescriptionUrl(),
+      this.updateOrderDescriptionPayload(payload.newName, orderItem),
+    );
+    // Keep session in sync so the current request reads back the new name.
+    this.context.session['hcl.cartName'] = payload.newName;
     return success(await this.fetchCart(payload.cart.key || undefined));
   }
 
@@ -435,7 +438,10 @@ export class HclCartCapability<
     if (payload.cart.key) {
       await this.fetchSetPendingOrder(payload.cart.key);
     }
-    await this.fetchAddPromotionCode(payload.couponCode);
+    await this.client.callPost<void>(
+      this.addPromotionCodeUrl(),
+      this.addPromotionCodePayload(payload.couponCode),
+    );
     return success(await this.fetchCart(payload.cart.key || undefined));
   }
 
@@ -450,7 +456,12 @@ export class HclCartCapability<
     if (payload.cart.key) {
       await this.fetchSetPendingOrder(payload.cart.key);
     }
-    await this.fetchRemovePromotionCode(payload.couponCode);
+    await this.client.callDelete(
+      this.removePromotionCodeUrl(payload.couponCode),
+      {
+        ignore404: true,
+      },
+    );
     return success(await this.fetchCart(payload.cart.key || undefined));
   }
 
@@ -468,9 +479,9 @@ export class HclCartCapability<
     const oldOrderId = oldCart.orderId;
 
     // Create a new order with the target currency.
-    const newOrder = await this.fetchCreateOrder(
-      oldCart.orderDescription,
-      payload.newCurrency,
+    const newOrder = await this.client.callPost<HclWcsCreateOrderResponse>(
+      `${this.createOrderUrl()}?${this.createOrderParams(oldCart.orderDescription, payload.newCurrency).toString()}`,
+      {},
     );
 
     // Make the new order the active (@self) one.
@@ -479,15 +490,16 @@ export class HclCartCapability<
     // Copy all items from the old order into the new one, priced in the new
     // currency by passing it as a query param on the add-item POST.
     for (const item of oldCart.orderItem ?? []) {
-      await this.fetchAddOrderItem(
-        item.partNumber,
-        Number(item.quantity),
-        payload.newCurrency,
+      await this.client.callPost<HclWcsOrderItemUpdateResponse>(
+        this.addOrderItemUrl(payload.newCurrency),
+        this.addOrderItemPayload(item.partNumber, Number(item.quantity)),
       );
     }
 
     // Cancel the old order.
-    await this.fetchDeleteCart(oldOrderId);
+    await this.client.callDelete(this.deleteCartUrl(oldOrderId), {
+      ignore404: true,
+    });
 
     return success(await this.fetchCart(newOrder.outOrderId));
   }

--- a/packages/hcl/src/capabilities/category.capability.ts
+++ b/packages/hcl/src/capabilities/category.capability.ts
@@ -58,9 +58,10 @@ export class HclCategoryCapability<
   public override async getById(
     payload: CategoryQueryById,
   ): Promise<Result<CategoryFactoryCategoryOutput<TFactory>, NotFoundError>> {
-    const response = await this.fetchCategories({
-      identifier: [payload.id.key],
-    });
+    const response = await this.client.callGet<HclCategoryQueryResponse>(
+      this.getByIdUrl(payload),
+      this.getByIdPayload(payload),
+    );
 
     const data = response.contents?.[0];
     if (!data) {
@@ -78,7 +79,12 @@ export class HclCategoryCapability<
     payload: CategoryQueryBySlug,
   ): Promise<Result<CategoryFactoryCategoryOutput<TFactory>, NotFoundError>> {
     // Use the URL token API to resolve the slug to a category uniqueID.
-    const token = await this.fetchBySlug(payload.slug);
+    const urlResponse = await this.client.callGet<HclUrlQueryResponse>(
+      this.urlsUrl(),
+      this.urlsParams(payload.slug),
+      { allowUndefined: true },
+    );
+    const token = urlResponse?.contents?.[0];
 
     if (
       !token ||
@@ -91,11 +97,10 @@ export class HclCategoryCapability<
       });
     }
 
-    const response = await this.fetchCategories({
-      // tokenValue is the numeric uniqueID; tokenExternalValue is the string identifier
-      // which the categories API rejects with 400 when used as an id= parameter.
-      id: [token.tokenValue],
-    });
+    const response = await this.client.callGet<HclCategoryQueryResponse>(
+      this.getBySlugUrl(token),
+      this.getBySlugPayload(token),
+    );
 
     const data = response.contents?.[0];
     if (!data) {
@@ -116,9 +121,10 @@ export class HclCategoryCapability<
     payload: CategoryQueryForBreadcrumb,
   ): Promise<Result<Array<CategoryFactoryCategoryOutput<TFactory>>>> {
     // Fetch the leaf category by external identifier.
-    const leafResponse = await this.fetchCategories({
-      identifier: [payload.id.key],
-    });
+    const leafResponse = await this.client.callGet<HclCategoryQueryResponse>(
+      this.getBreadcrumbLeafUrl(payload),
+      this.getBreadcrumbLeafPayload(payload),
+    );
 
     const leafData = leafResponse.contents?.[0];
     if (!leafData) {
@@ -140,7 +146,10 @@ export class HclCategoryCapability<
     // Fetch all ancestors in a single request — the id param accepts multiple values.
     const ancestorsResp =
       ancestorIds.length > 0
-        ? await this.fetchCategories({ id: ancestorIds })
+        ? await this.client.callGet<HclCategoryQueryResponse>(
+            this.getBreadcrumbAncestorsUrl(ancestorIds),
+            this.getBreadcrumbAncestorsPayload(ancestorIds),
+          )
         : { contents: [] };
 
     // Re-order results to match the original root-first order from pathSegments,
@@ -171,9 +180,10 @@ export class HclCategoryCapability<
   ): Promise<Result<CategoryFactoryPaginatedOutput<TFactory>, NotFoundError>> {
     // Resolve the external identifier to an internal uniqueID.
     // HCL's parentCategoryId parameter requires the internal uniqueID.
-    const parentResp = await this.fetchCategories({
-      identifier: [payload.parentId.key],
-    });
+    const parentResp = await this.client.callGet<HclCategoryQueryResponse>(
+      this.findChildCategoriesParentUrl(payload),
+      this.findChildCategoriesParentPayload(payload),
+    );
     const parentUniqueId = parentResp.contents?.[0]?.uniqueID;
 
     if (!parentUniqueId) {
@@ -183,10 +193,10 @@ export class HclCategoryCapability<
       });
     }
 
-    const response = await this.fetchCategories({
-      parentCategoryId: parentUniqueId,
-      depthAndLimit: '1,0',
-    });
+    const response = await this.client.callGet<HclCategoryQueryResponse>(
+      this.findChildCategoriesUrl(parentUniqueId),
+      this.findChildCategoriesPayload(parentUniqueId),
+    );
 
     const items = response.contents ?? [];
     const paginated = this.factory.parseCategoryPaginatedResult(
@@ -206,9 +216,10 @@ export class HclCategoryCapability<
     payload: CategoryQueryForTopCategories,
   ): Promise<Result<CategoryFactoryPaginatedOutput<TFactory>>> {
     // Fetching without a parentCategoryId returns root-level categories.
-    const response = await this.fetchCategories({
-      depthAndLimit: '1,0',
-    });
+    const response = await this.client.callGet<HclCategoryQueryResponse>(
+      this.findTopCategoriesUrl(payload),
+      this.findTopCategoriesPayload(),
+    );
 
     const items = response.contents ?? [];
     const paginated = this.factory.parseCategoryPaginatedResult(
@@ -220,9 +231,84 @@ export class HclCategoryCapability<
     return success(paginated as CategoryFactoryPaginatedOutput<TFactory>);
   }
 
-  protected async fetchCategories(
-    query: HclFindCategoriesQuery,
-  ): Promise<HclCategoryQueryResponse> {
+  protected getByIdUrl(_payload: CategoryQueryById): string {
+    return this.categoriesUrl();
+  }
+
+  protected getBySlugUrl(_token: HclUrlResponse): string {
+    return this.categoriesUrl();
+  }
+
+  protected getBreadcrumbLeafUrl(_payload: CategoryQueryForBreadcrumb): string {
+    return this.categoriesUrl();
+  }
+
+  protected getBreadcrumbAncestorsUrl(_ancestorIds: string[]): string {
+    return this.categoriesUrl();
+  }
+
+  protected findChildCategoriesParentUrl(
+    _payload: CategoryQueryForChildCategories,
+  ): string {
+    return this.categoriesUrl();
+  }
+
+  protected findChildCategoriesUrl(_parentUniqueId: string): string {
+    return this.categoriesUrl();
+  }
+
+  protected findTopCategoriesUrl(
+    _payload: CategoryQueryForTopCategories,
+  ): string {
+    return this.categoriesUrl();
+  }
+
+  protected getByIdPayload(payload: CategoryQueryById): URLSearchParams {
+    return this.categoriesParams({ identifier: [payload.id.key] });
+  }
+
+  // tokenValue is the numeric uniqueID; tokenExternalValue is the string identifier
+  // which the categories API rejects with 400 when used as an id= parameter.
+  protected getBySlugPayload(token: HclUrlResponse): URLSearchParams {
+    return this.categoriesParams({ id: [token.tokenValue] });
+  }
+
+  protected getBreadcrumbLeafPayload(
+    payload: CategoryQueryForBreadcrumb,
+  ): URLSearchParams {
+    return this.categoriesParams({ identifier: [payload.id.key] });
+  }
+
+  protected getBreadcrumbAncestorsPayload(
+    ancestorIds: string[],
+  ): URLSearchParams {
+    return this.categoriesParams({ id: ancestorIds });
+  }
+
+  protected findChildCategoriesParentPayload(
+    payload: CategoryQueryForChildCategories,
+  ): URLSearchParams {
+    return this.categoriesParams({ identifier: [payload.parentId.key] });
+  }
+
+  protected findChildCategoriesPayload(
+    parentUniqueId: string,
+  ): URLSearchParams {
+    return this.categoriesParams({
+      parentCategoryId: parentUniqueId,
+      depthAndLimit: '1,0',
+    });
+  }
+
+  protected findTopCategoriesPayload(): URLSearchParams {
+    return this.categoriesParams({ depthAndLimit: '1,0' });
+  }
+
+  protected categoriesUrl(): string {
+    return `${this.client.catalogBaseUrl}/api/v2/categories`;
+  }
+
+  protected categoriesParams(query: HclFindCategoriesQuery): URLSearchParams {
     const params = new URLSearchParams();
     params.set('storeId', query.storeId ?? this.config.storeId);
     const catalogId = query.catalogId ?? this.config.catalogId;
@@ -234,23 +320,17 @@ export class HclCategoryCapability<
     for (const id of query.id ?? []) params.append('id', id);
     for (const identifier of query.identifier ?? [])
       params.append('identifier', identifier);
-    return this.client.callGet<HclCategoryQueryResponse>(
-      `${this.client.catalogBaseUrl}/api/v2/categories`,
-      params,
-    );
+    return params;
   }
 
-  protected async fetchBySlug(
-    slug: string,
-  ): Promise<HclUrlResponse | undefined> {
+  protected urlsUrl(): string {
+    return `${this.client.catalogBaseUrl}/api/v2/urls`;
+  }
+
+  protected urlsParams(slug: string): URLSearchParams {
     const params = new URLSearchParams();
     params.set('storeId', this.config.storeId);
     params.append('identifier', slug);
-    const response = await this.client.callGet<HclUrlQueryResponse>(
-      `${this.client.catalogBaseUrl}/api/v2/urls`,
-      params,
-      { allowUndefined: true },
-    );
-    return response?.contents?.[0];
+    return params;
   }
 }

--- a/packages/hcl/src/capabilities/checkout.capability.ts
+++ b/packages/hcl/src/capabilities/checkout.capability.ts
@@ -72,10 +72,14 @@ export class HclCheckoutCapability<
     this.factory = factory;
   }
 
+  protected cartUrl(): string {
+    return `${this.client.transactionBaseUrl}/cart/@self`;
+  }
+
   /** Fetch the raw WCS cart response. Throws HclCartNotFoundError on 404. */
   protected async fetchWcsCart(): Promise<HclWcsCartResponse> {
     const data = await this.client.callGet<HclWcsCartResponse>(
-      `${this.client.transactionBaseUrl}/cart/@self`,
+      this.cartUrl(),
       undefined,
       { allowUndefined: true },
     );
@@ -91,104 +95,64 @@ export class HclCheckoutCapability<
     return this.factory.parseCheckout(this.context, { ...data, ...extra });
   }
 
-  /** Fetch available payment methods. Returns empty list if endpoint returns 404. */
-  protected async fetchPaymentMethods(): Promise<HclWcsPaymentMethodsResponse> {
-    const data = await this.client.callGet<HclWcsPaymentMethodsResponse>(
-      `${this.client.transactionBaseUrl}/cart/@self/payment_instruction/eligible_payment_info`,
-      undefined,
-      { allowUndefined: true },
-    );
-    return data ?? { usablePaymentInformation: [] };
+  protected paymentMethodsUrl(): string {
+    return `${this.client.transactionBaseUrl}/cart/@self/payment_instruction/eligible_payment_info`;
   }
 
-  /** Add a payment instruction to the cart. */
-  protected async fetchAddPaymentInstruction(body: {
-    payMethodId: string;
-    piAmount?: string;
-    protocolData?: { name: string; value: string }[];
-    billing_address_id?: string;
-    billto_firstName?: string;
-    billto_lastName?: string;
-    billto_address1?: string;
-    billto_city?: string;
-    billto_state?: string;
-    billto_zipCode?: string;
-    billto_country?: string;
-    billto_phone1?: string;
-    billto_email1?: string;
-  }): Promise<{ piId: string }> {
-    return this.client.callPost<{ piId: string }>(
-      `${this.client.transactionBaseUrl}/cart/@self/payment_instruction`,
-      body,
-    );
+  protected addPaymentInstructionUrl(): string {
+    return `${this.client.transactionBaseUrl}/cart/@self/payment_instruction`;
   }
 
-  /** Delete a payment instruction from the cart. */
-  protected async fetchDeletePaymentInstruction(piId: string): Promise<void> {
-    return this.client.callDelete(
-      `${this.client.transactionBaseUrl}/cart/@self/payment_instruction/${encodeURIComponent(piId)}`,
-      { ignore404: true },
-    );
+  protected deletePaymentInstructionUrl(piId: string): string {
+    return `${this.client.transactionBaseUrl}/cart/@self/payment_instruction/${encodeURIComponent(piId)}`;
   }
 
-  /** Fetch available shipping modes. */
-  protected async fetchShippingModes(): Promise<HclWcsShipModesResponse> {
+  protected shippingModesUrl(): string {
+    return `${this.client.transactionBaseUrl}/cart/@self/shipping_info`;
+  }
+
+  protected shippingModesParams(): URLSearchParams {
     const params = new URLSearchParams();
     params.set('profileName', 'IBM_usableShippingMode');
-    return this.client.callGet<HclWcsShipModesResponse>(
-      `${this.client.transactionBaseUrl}/cart/@self/shipping_info`,
-      params,
-    );
+    return params;
   }
 
-  /** Set the shipping mode (and optionally inline address) on the cart. */
-  protected async fetchSetShippingInfo(body: {
+  protected shippingInfoUrl(): string {
+    return `${this.client.transactionBaseUrl}/cart/@self/shipping_info`;
+  }
+
+  protected setShippingInfoPayload(body: {
     shipModeId?: string;
     orderItemId?: string[];
     x_addr?: HclWcsAddress;
-  }): Promise<HclWcsOrderIdContainer> {
-    return this.client.callPut<HclWcsOrderIdContainer>(
-      `${this.client.transactionBaseUrl}/cart/@self/shipping_info`,
-      {
-        ...body,
-        x_calculateOrder: '1',
-        x_calculationUsage: '-1,-2,-3,-4,-5,-6,-7',
-      },
-    );
+  }): object {
+    return {
+      ...body,
+      x_calculateOrder: '1',
+      x_calculationUsage: '-1,-2,-3,-4,-5,-6,-7',
+    };
   }
 
-  /** Set an inline shipping address on each order item. */
-  protected async fetchSetShippingAddressForItems(
+  protected setShippingAddressForItemsPayload(
     orderItemIds: string[],
     addr: HclWcsAddress,
-  ): Promise<HclWcsOrderIdContainer> {
-    return this.client.callPut<HclWcsOrderIdContainer>(
-      `${this.client.transactionBaseUrl}/cart/@self/shipping_info`,
-      {
-        x_calculateOrder: '1',
-        x_calculationUsage: '-1,-2,-3,-4,-5,-6,-7',
-        orderItem: orderItemIds.map((orderItemId) => ({
-          orderItemId,
-          x_addr: addr,
-        })),
-      },
-    );
+  ): object {
+    return {
+      x_calculateOrder: '1',
+      x_calculationUsage: '-1,-2,-3,-4,-5,-6,-7',
+      orderItem: orderItemIds.map((orderItemId) => ({
+        orderItemId,
+        x_addr: addr,
+      })),
+    };
   }
 
-  /** Pre-checkout validation — must be called before fetchSubmitCheckout(). */
-  protected async fetchPrecheckout(): Promise<HclWcsOrderIdContainer> {
-    return this.client.callPut<HclWcsOrderIdContainer>(
-      `${this.client.transactionBaseUrl}/cart/@self/precheckout`,
-      {},
-    );
+  protected precheckoutUrl(): string {
+    return `${this.client.transactionBaseUrl}/cart/@self/precheckout`;
   }
 
-  /** Submit the cart as an order. */
-  protected async fetchSubmitCheckout(): Promise<HclWcsOrderIdContainer> {
-    return this.client.callPost<HclWcsOrderIdContainer>(
-      `${this.client.transactionBaseUrl}/cart/@self/checkout`,
-      {},
-    );
+  protected submitCheckoutUrl(): string {
+    return `${this.client.transactionBaseUrl}/cart/@self/checkout`;
   }
 
   @Reactionary({
@@ -214,28 +178,42 @@ export class HclCheckoutCapability<
       const addr = payload.billingAddress;
 
       // Get the first available payment method to use as a placeholder.
-      const methodsResp = await this.fetchPaymentMethods();
+      const methodsResp =
+        (await this.client.callGet<HclWcsPaymentMethodsResponse>(
+          this.paymentMethodsUrl(),
+          undefined,
+          { allowUndefined: true },
+        )) ?? { usablePaymentInformation: [] };
       const firstMethod = methodsResp.usablePaymentInformation?.[0];
 
       if (firstMethod) {
         // Delete any existing PIs first (mirrors upsertBillingAddress).
         const cartData = await this.fetchWcsCart();
         for (const pi of cartData.paymentInstruction ?? []) {
-          await this.fetchDeletePaymentInstruction(pi.piId);
+          await this.client.callDelete(
+            this.deletePaymentInstructionUrl(pi.piId),
+            {
+              ignore404: true,
+            },
+          );
         }
 
-        await this.fetchAddPaymentInstruction({
-          payMethodId: firstMethod.paymentMethodName,
-          billto_firstName: addr.firstName,
-          billto_lastName: addr.lastName,
-          billto_address1: `${addr.streetAddress} ${addr.streetNumber}`.trim(),
-          billto_city: addr.city,
-          billto_state: addr.region,
-          billto_zipCode: addr.postalCode,
-          billto_country: addr.countryCode,
-          billto_phone1: payload.notificationPhone,
-          billto_email1: payload.notificationEmail,
-        });
+        await this.client.callPost<{ piId: string }>(
+          this.addPaymentInstructionUrl(),
+          {
+            payMethodId: firstMethod.paymentMethodName,
+            billto_firstName: addr.firstName,
+            billto_lastName: addr.lastName,
+            billto_address1:
+              `${addr.streetAddress} ${addr.streetNumber}`.trim(),
+            billto_city: addr.city,
+            billto_state: addr.region,
+            billto_zipCode: addr.postalCode,
+            billto_country: addr.countryCode,
+            billto_phone1: payload.notificationPhone,
+            billto_email1: payload.notificationEmail,
+          },
+        );
       }
     }
     return success(await this.fetchCheckout());
@@ -271,15 +249,18 @@ export class HclCheckoutCapability<
     const cartData = await this.fetchWcsCart();
     const orderItemIds = (cartData.orderItem ?? []).map((i) => i.orderItemId);
     const addr = payload.shippingAddress;
-    await this.fetchSetShippingAddressForItems(orderItemIds, {
-      firstName: addr.firstName,
-      lastName: addr.lastName,
-      address1: `${addr.streetAddress} ${addr.streetNumber}`.trim(),
-      city: addr.city,
-      state: addr.region,
-      zipCode: addr.postalCode,
-      country: addr.countryCode,
-    });
+    await this.client.callPut<HclWcsOrderIdContainer>(
+      this.shippingInfoUrl(),
+      this.setShippingAddressForItemsPayload(orderItemIds, {
+        firstName: addr.firstName,
+        lastName: addr.lastName,
+        address1: `${addr.streetAddress} ${addr.streetNumber}`.trim(),
+        city: addr.city,
+        state: addr.region,
+        zipCode: addr.postalCode,
+        country: addr.countryCode,
+      }),
+    );
     return success(await this.fetchCheckout());
   }
 
@@ -291,7 +272,10 @@ export class HclCheckoutCapability<
     _payload: CheckoutQueryForAvailableShippingMethods,
   ): Promise<Result<CheckoutFactoryShippingMethodOutput<TFactory>[]>> {
     debug('getAvailableShippingMethods');
-    const response = await this.fetchShippingModes();
+    const response = await this.client.callGet<HclWcsShipModesResponse>(
+      this.shippingModesUrl(),
+      this.shippingModesParams(),
+    );
     // Newer WCS returns usableShippingMode at root; older WCS embeds modes in orderItem.
     let modes: CheckoutFactoryShippingMethodOutput<TFactory>[];
     if (response.usableShippingMode && response.usableShippingMode.length > 0) {
@@ -331,7 +315,11 @@ export class HclCheckoutCapability<
     _payload: CheckoutQueryForAvailablePaymentMethods,
   ): Promise<Result<CheckoutFactoryPaymentMethodOutput<TFactory>[]>> {
     debug('getAvailablePaymentMethods');
-    const response = await this.fetchPaymentMethods();
+    const response = (await this.client.callGet<HclWcsPaymentMethodsResponse>(
+      this.paymentMethodsUrl(),
+      undefined,
+      { allowUndefined: true },
+    )) ?? { usablePaymentInformation: [] };
     const methods = (response.usablePaymentInformation ?? []).map((method) =>
       this.factory.parsePaymentMethod(this.context, method),
     );
@@ -349,16 +337,19 @@ export class HclCheckoutCapability<
       'addPaymentInstruction payMethodId=%s',
       payload.paymentInstruction.paymentMethod.method,
     );
-    await this.fetchAddPaymentInstruction({
-      payMethodId: payload.paymentInstruction.paymentMethod.method,
-      piAmount: payload.paymentInstruction.amount
-        ? String(payload.paymentInstruction.amount.value)
-        : undefined,
-      protocolData: payload.paymentInstruction.protocolData.map((pd) => ({
-        name: pd.key,
-        value: pd.value,
-      })),
-    });
+    await this.client.callPost<{ piId: string }>(
+      this.addPaymentInstructionUrl(),
+      {
+        payMethodId: payload.paymentInstruction.paymentMethod.method,
+        piAmount: payload.paymentInstruction.amount
+          ? String(payload.paymentInstruction.amount.value)
+          : undefined,
+        protocolData: payload.paymentInstruction.protocolData.map((pd) => ({
+          name: pd.key,
+          value: pd.value,
+        })),
+      },
+    );
     return success(await this.fetchCheckout());
   }
 
@@ -370,7 +361,12 @@ export class HclCheckoutCapability<
     payload: CheckoutMutationRemovePaymentInstruction,
   ): Promise<Result<CheckoutFactoryCheckoutOutput<TFactory>>> {
     debug('removePaymentInstruction piId=%s', payload.paymentInstruction.key);
-    await this.fetchDeletePaymentInstruction(payload.paymentInstruction.key);
+    await this.client.callDelete(
+      this.deletePaymentInstructionUrl(payload.paymentInstruction.key),
+      {
+        ignore404: true,
+      },
+    );
     return success(await this.fetchCheckout());
   }
 
@@ -389,10 +385,13 @@ export class HclCheckoutCapability<
     const cartData = await this.fetchWcsCart();
     const orderItemIds = (cartData.orderItem ?? []).map((i) => i.orderItemId);
 
-    await this.fetchSetShippingInfo({
-      shipModeId: payload.shippingInstruction.shippingMethod.key,
-      orderItemId: orderItemIds,
-    });
+    await this.client.callPut<HclWcsOrderIdContainer>(
+      this.shippingInfoUrl(),
+      this.setShippingInfoPayload({
+        shipModeId: payload.shippingInstruction.shippingMethod.key,
+        orderItemId: orderItemIds,
+      }),
+    );
     return success(await this.fetchCheckout());
   }
 
@@ -407,8 +406,14 @@ export class HclCheckoutCapability<
     // Save cart state before submission (after checkout the cart is gone).
     const cartBefore = await this.fetchWcsCart();
 
-    await this.fetchPrecheckout();
-    const result = await this.fetchSubmitCheckout();
+    await this.client.callPut<HclWcsOrderIdContainer>(
+      this.precheckoutUrl(),
+      {},
+    );
+    const result = await this.client.callPost<HclWcsOrderIdContainer>(
+      this.submitCheckoutUrl(),
+      {},
+    );
 
     // In WCS, the orderId returned by checkout IS the same as the cart orderId
     // (same entity, status changed from 'P' to 'C').

--- a/packages/hcl/src/capabilities/identity.capability.ts
+++ b/packages/hcl/src/capabilities/identity.capability.ts
@@ -24,10 +24,7 @@ import {
 import type { HclConfiguration } from '../schema/configuration.schema.js';
 import type { HclClient } from '../core/client.js';
 import type { HclIdentityFactory } from '../factories/identity/identity.factory.js';
-import type {
-  HclPersonResponse,
-  HclWcsIdentityResponse,
-} from '../schema/hcl.schema.js';
+import type { HclWcsIdentityResponse } from '../schema/hcl.schema.js';
 import {
   SESSION_KEY_WC_TOKEN,
   SESSION_KEY_WC_TRUSTED_TOKEN,
@@ -135,9 +132,9 @@ export class HclIdentityCapability<
   ): Promise<Result<IdentityFactoryOutput<TFactory>>> {
     debug('Attempting login for user: %s', payload.username);
 
-    const response = await this.loginIdentity(
-      payload.username,
-      payload.password,
+    const response = await this.client.callPost<HclWcsIdentityResponse>(
+      this.loginIdentityUrl(),
+      this.loginIdentityPayload(payload.username, payload.password),
     );
 
     this.storeSessionTokens(
@@ -176,7 +173,9 @@ export class HclIdentityCapability<
     // Auth headers are read automatically from the context by the client.
     if (wcToken && userId) {
       try {
-        await this.deleteLoginIdentity(userId);
+        await this.client.callDelete(this.deleteLoginIdentityUrl(userId), {
+          ignore404: true,
+        });
       } catch (err) {
         debug('Server-side logout failed (non-fatal): %o', err);
       }
@@ -201,7 +200,9 @@ export class HclIdentityCapability<
     debug('Registering new user: %s', payload.username);
 
     // WCS requires a guest session before registering a new person.
-    const guest = await this.createGuestIdentity();
+    const guest = await this.client.callPost<HclWcsIdentityResponse>(
+      this.createGuestIdentityUrl(),
+    );
     this.storeSessionTokens(
       guest.WCToken,
       guest.WCTrustedToken,
@@ -212,9 +213,9 @@ export class HclIdentityCapability<
 
     // Register the person — the guest session tokens are now stored in the
     // context so the client reads them automatically via buildHeaders().
-    const registered = await this.registerPerson(
-      payload.username,
-      payload.password,
+    const registered = await this.client.callPut<HclWcsIdentityResponse>(
+      this.registerPersonUrl(),
+      this.registerPersonPayload(payload.username, payload.password),
     );
 
     this.storeSessionTokens(
@@ -259,59 +260,37 @@ export class HclIdentityCapability<
     delete this.context.session[SESSION_KEY_PERSONALIZATION_ID];
   }
 
-  // ---------------------------------------------------------------------------
-  // Protected fetch methods — override in subclasses to customise API calls
-  // ---------------------------------------------------------------------------
+  protected loginIdentityUrl(): string {
+    return `${this.client.transactionBaseUrl}/loginidentity`;
+  }
 
-  protected async loginIdentity(
+  protected loginIdentityPayload(
     logonId: string,
     logonPassword: string,
-  ): Promise<HclWcsIdentityResponse> {
-    return this.client.callPost<HclWcsIdentityResponse>(
-      `${this.client.transactionBaseUrl}/loginidentity`,
-      { logonId, logonPassword },
-    );
+  ): { logonId: string; logonPassword: string } {
+    return { logonId, logonPassword };
   }
 
-  protected async deleteLoginIdentity(userId: string): Promise<void> {
-    await this.client.callDelete(
-      `${this.client.transactionBaseUrl}/loginidentity/${encodeURIComponent(userId)}`,
-      { ignore404: true },
-    );
+  protected deleteLoginIdentityUrl(userId: string): string {
+    return `${this.client.transactionBaseUrl}/loginidentity/${encodeURIComponent(userId)}`;
   }
 
-  /**
-   * Create an anonymous guest session.
-   * Only call this when the user actually needs a persisted session (e.g. on
-   * cart creation). For pure browsing, a personalization ID is sufficient.
-   */
-  protected async createGuestIdentity(): Promise<HclWcsIdentityResponse> {
-    return this.client.callPost<HclWcsIdentityResponse>(
-      `${this.client.transactionBaseUrl}/guestidentity`,
-    );
+  protected createGuestIdentityUrl(): string {
+    return `${this.client.transactionBaseUrl}/guestidentity`;
   }
 
-  /**
-   * Register a new person. Requires an active guest session already stored in
-   * the context (guest tokens are picked up automatically by buildHeaders).
-   */
-  protected async registerPerson(
+  protected registerPersonUrl(): string {
+    return `${this.client.transactionBaseUrl}/person/@self`;
+  }
+
+  protected registerPersonPayload(
     logonId: string,
     logonPassword: string,
-  ): Promise<HclWcsIdentityResponse> {
-    return this.client.callPut<HclWcsIdentityResponse>(
-      `${this.client.transactionBaseUrl}/person/@self`,
-      {
-        logonId,
-        logonPassword,
-        logonPasswordVerify: logonPassword,
-      },
-    );
-  }
-
-  protected async getSelfPerson(): Promise<HclPersonResponse> {
-    return this.client.callGet<HclPersonResponse>(
-      `${this.client.transactionBaseUrl}/person/@self`,
-    );
+  ): {
+    logonId: string;
+    logonPassword: string;
+    logonPasswordVerify: string;
+  } {
+    return { logonId, logonPassword, logonPasswordVerify: logonPassword };
   }
 }

--- a/packages/hcl/src/capabilities/inventory.capability.ts
+++ b/packages/hcl/src/capabilities/inventory.capability.ts
@@ -42,7 +42,10 @@ export class HclInventoryCapability<
     const { sku } = payload.variant;
     const centreKey = payload.fulfilmentCenter.key;
 
-    const response = await this.fetchInventory(sku, centreKey || undefined);
+    const response = await this.client.callGet<HclInventoryAvailabilityResponse>(
+      this.getBySKUUrl(payload),
+      this.getBySKUPayload(payload),
+    );
 
     const items = response.InventoryAvailability ?? [];
 
@@ -74,25 +77,14 @@ export class HclInventoryCapability<
     );
   }
 
-  /**
-   * Fetch inventory availability for a single SKU from WCS.
-   *
-   * Calls GET /inventoryavailability/byPartNumber/{sku}[?physicalStoreName=X]
-   *
-   * The URL logic lives here (not in the transaction client) so that
-   * project-level subclasses can override this method to add extra parameters
-   * or use a different inventory endpoint.
-   */
-  protected async fetchInventory(
-    sku: string,
-    physicalStoreName?: string,
-  ): Promise<HclInventoryAvailabilityResponse> {
-    const params = new URLSearchParams();
-    if (physicalStoreName) params.set('physicalStoreName', physicalStoreName);
+  protected getBySKUUrl(payload: InventoryQueryBySKU): string {
+    return `${this.client.transactionBaseUrl}/inventoryavailability/byPartNumber/${encodeURIComponent(payload.variant.sku)}`;
+  }
 
-    return this.client.callGet<HclInventoryAvailabilityResponse>(
-      `${this.client.transactionBaseUrl}/inventoryavailability/byPartNumber/${encodeURIComponent(sku)}`,
-      params,
-    );
+  protected getBySKUPayload(payload: InventoryQueryBySKU): URLSearchParams {
+    const params = new URLSearchParams();
+    const centreKey = payload.fulfilmentCenter.key;
+    if (centreKey) params.set('physicalStoreName', centreKey);
+    return params;
   }
 }

--- a/packages/hcl/src/capabilities/price.capability.ts
+++ b/packages/hcl/src/capabilities/price.capability.ts
@@ -43,100 +43,40 @@ export class HclPriceCapability<
   public override async getListPrice(
     payload: ListPriceQuery,
   ): Promise<Result<PriceFactoryOutput<TFactory>>> {
-    // In HCL Commerce the public catalogue price is provided by the
-    // display_price endpoint (as opposed to the session-aware entitled price).
-    return this.fetchDisplayPrice(payload.variant.sku);
-  }
-
-  @Reactionary({
-    inputSchema: CustomerPriceQuerySchema,
-    outputSchema: PriceSchema,
-  })
-  public override async getCustomerPrice(
-    payload: CustomerPriceQuery,
-  ): Promise<Result<PriceFactoryOutput<TFactory>>> {
-    // The entitled-price endpoint (/price?q=byPartNumbers) automatically
-    // applies the session's organisation contract for authenticated B2B users,
-    // so no explicit price-rule ID is required here.
-    return this.fetchEntitledPrice(payload.variant.sku);
-  }
-
-  /**
-   * Fetch the display (list) price for a single SKU.
-   *
-   * Calls GET /display_price?q=byPartNumbersAndPriceRuleId&priceRuleId={id}&partNumber={sku}
-   *
-   * Requires `hcl.priceRuleId` to be set in the request context session.
-   * Falls back to fetchEntitledPrice when no price rule ID is available.
-   */
-  protected async fetchDisplayPrice(
-    sku: string | string[],
-  ): Promise<Result<PriceFactoryOutput<TFactory>>> {
-    const skus = Array.isArray(sku) ? sku : [sku];
-    const primarySku = skus[0];
+    const sku = payload.variant.sku;
     const priceRuleId = this.context.session[SESSION_KEY_PRICE_RULE_ID] as
       | string
       | undefined;
+
     if (!priceRuleId) {
       // display_price requires a priceRuleId — fall back to entitled price.
-      return this.fetchEntitledPrice(primarySku);
-    }
-    const params = new URLSearchParams();
-    params.set('q', 'byPartNumbersAndPriceRuleId');
-    params.set('priceRuleId', priceRuleId);
-    for (const s of skus) {
-      params.append('partNumber', s);
-    }
-
-    const response = await this.client.callGet<HclDisplayPriceResponse>(
-      `${this.client.transactionBaseUrl}/display_price`,
-      params,
-    );
-
-    const rawItem = response.resultList?.find(
-      (i) => i.partNumber === primarySku,
-    );
-
-    if (!rawItem) {
+      const response = await this.client.callGet<HclEntitledPriceResponse>(
+        this.getCustomerPriceUrl(),
+        this.getCustomerPricePayload(sku),
+      );
+      const rawItem = response.EntitledPrice?.find((i) => i.partNumber === sku);
+      if (!rawItem) {
+        return success(
+          this.factory.parsePrice(this.context, {
+            item: { partNumber: sku },
+          }) as PriceFactoryOutput<TFactory>,
+        );
+      }
       return success(
         this.factory.parsePrice(this.context, {
-          item: { partNumber: primarySku },
+          item: rawItem,
         }) as PriceFactoryOutput<TFactory>,
       );
     }
 
-    return success(
-      this.factory.parsePrice(this.context, {
-        item: rawItem,
-      }) as PriceFactoryOutput<TFactory>,
-    );
-  }
-
-  /**
-   * Fetch the entitled price for a single SKU.
-   *
-   * Calls GET /price?q=byPartNumbers&partNumber={sku}[&currency=X]
-   *
-   * The URL and query-parameter logic lives here (not in the transaction
-   * client) so that project-level subclasses can override this method to add
-   * extra parameters, switch endpoints, or apply custom logic.
-   */
-  protected async fetchEntitledPrice(
-    sku: string,
-  ): Promise<Result<PriceFactoryOutput<TFactory>>> {
-    const params = new URLSearchParams();
-    params.set('q', 'byPartNumbers');
-    params.append('partNumber', sku);
-
-    const response = await this.client.callGet<HclEntitledPriceResponse>(
-      `${this.client.transactionBaseUrl}/price`,
-      params,
+    const response = await this.client.callGet<HclDisplayPriceResponse>(
+      this.getListPriceUrl(),
+      this.getListPricePayload(sku, priceRuleId),
     );
 
-    const rawItem = response.EntitledPrice?.find((i) => i.partNumber === sku);
+    const rawItem = response.resultList?.find((i) => i.partNumber === sku);
 
     if (!rawItem) {
-      // Return a zero/empty placeholder consistent with PriceCapability semantics.
       return success(
         this.factory.parsePrice(this.context, {
           item: { partNumber: sku },
@@ -149,5 +89,58 @@ export class HclPriceCapability<
         item: rawItem,
       }) as PriceFactoryOutput<TFactory>,
     );
+  }
+
+  @Reactionary({
+    inputSchema: CustomerPriceQuerySchema,
+    outputSchema: PriceSchema,
+  })
+  public override async getCustomerPrice(
+    payload: CustomerPriceQuery,
+  ): Promise<Result<PriceFactoryOutput<TFactory>>> {
+    const sku = payload.variant.sku;
+    const response = await this.client.callGet<HclEntitledPriceResponse>(
+      this.getCustomerPriceUrl(),
+      this.getCustomerPricePayload(sku),
+    );
+    const rawItem = response.EntitledPrice?.find((i) => i.partNumber === sku);
+    if (!rawItem) {
+      return success(
+        this.factory.parsePrice(this.context, {
+          item: { partNumber: sku },
+        }) as PriceFactoryOutput<TFactory>,
+      );
+    }
+    return success(
+      this.factory.parsePrice(this.context, {
+        item: rawItem,
+      }) as PriceFactoryOutput<TFactory>,
+    );
+  }
+
+  protected getListPriceUrl(): string {
+    return `${this.client.transactionBaseUrl}/display_price`;
+  }
+
+  protected getListPricePayload(
+    sku: string,
+    priceRuleId: string,
+  ): URLSearchParams {
+    const params = new URLSearchParams();
+    params.set('q', 'byPartNumbersAndPriceRuleId');
+    params.set('priceRuleId', priceRuleId);
+    params.append('partNumber', sku);
+    return params;
+  }
+
+  protected getCustomerPriceUrl(): string {
+    return `${this.client.transactionBaseUrl}/price`;
+  }
+
+  protected getCustomerPricePayload(sku: string): URLSearchParams {
+    const params = new URLSearchParams();
+    params.set('q', 'byPartNumbers');
+    params.append('partNumber', sku);
+    return params;
   }
 }

--- a/packages/hcl/src/capabilities/product-search.capability.ts
+++ b/packages/hcl/src/capabilities/product-search.capability.ts
@@ -42,13 +42,13 @@ export class HclProductSearchCapability<
 
   protected queryByTermPayload(
     payload: ProductSearchQueryByTerm,
-  ): HclFindProductsQuery {
+  ): URLSearchParams {
     const { term, paginationOptions, categoryFilter, facets } = payload.search;
     const { pageNumber, pageSize } = paginationOptions;
 
     const categoryId = categoryFilter?.key || undefined;
 
-    return {
+    return this.productsParams({
       searchTerm: term || undefined,
       categoryId,
       limit: pageSize,
@@ -57,7 +57,7 @@ export class HclProductSearchCapability<
         ? this.config.profiles.categoryBrowse
         : this.config.profiles.productSearch,
       facets: facets.length > 0 ? facets.map((f) => f.key) : undefined,
-    };
+    });
   }
 
   @Reactionary({
@@ -67,7 +67,10 @@ export class HclProductSearchCapability<
   public override async queryByTerm(
     payload: ProductSearchQueryByTerm,
   ): Promise<Result<ProductSearchFactoryOutput<TFactory>>> {
-    const response = await this.fetchProducts(this.queryByTermPayload(payload));
+    const response = await this.client.callGet<HclProductQueryResponse>(
+      this.queryByTermUrl(payload),
+      this.queryByTermPayload(payload),
+    );
 
     const value = this.factory.parseSearchResult(
       this.context,
@@ -93,9 +96,10 @@ export class HclProductSearchCapability<
 
     let uniqueId = leaf?.uniqueId;
     if (!uniqueId) {
-      const catResp = await this.fetchCategories({
-        identifier: [externalKey],
-      });
+      const catResp = await this.client.callGet<HclCategoryQueryResponse>(
+        this.categoriesUrl(),
+        this.categoriesParams({ identifier: [externalKey] }),
+      );
       uniqueId = catResp.contents?.[0]?.uniqueID ?? externalKey;
     }
 
@@ -106,9 +110,15 @@ export class HclProductSearchCapability<
     return success(filter);
   }
 
-  protected async fetchProducts(
-    query: HclFindProductsQuery,
-  ): Promise<HclProductQueryResponse> {
+  protected queryByTermUrl(_payload: ProductSearchQueryByTerm): string {
+    return this.productsUrl();
+  }
+
+  protected productsUrl(): string {
+    return `${this.client.catalogBaseUrl}/api/v2/products`;
+  }
+
+  protected productsParams(query: HclFindProductsQuery): URLSearchParams {
     const params = new URLSearchParams();
     params.set('storeId', query.storeId ?? this.config.storeId);
     const catalogId = query.catalogId ?? this.config.catalogId;
@@ -124,15 +134,14 @@ export class HclProductSearchCapability<
     for (const id of query.id ?? []) params.append('id', id);
     for (const pn of query.partNumber ?? []) params.append('partNumber', pn);
     for (const facet of query.facets ?? []) params.append('facet', facet);
-    return this.client.callGet<HclProductQueryResponse>(
-      `${this.client.catalogBaseUrl}/api/v2/products`,
-      params,
-    );
+    return params;
   }
 
-  protected async fetchCategories(
-    query: HclFindCategoriesQuery,
-  ): Promise<HclCategoryQueryResponse> {
+  protected categoriesUrl(): string {
+    return `${this.client.catalogBaseUrl}/api/v2/categories`;
+  }
+
+  protected categoriesParams(query: HclFindCategoriesQuery): URLSearchParams {
     const params = new URLSearchParams();
     params.set('storeId', query.storeId ?? this.config.storeId);
     const catalogId = query.catalogId ?? this.config.catalogId;
@@ -144,9 +153,7 @@ export class HclProductSearchCapability<
     for (const id of query.id ?? []) params.append('id', id);
     for (const identifier of query.identifier ?? [])
       params.append('identifier', identifier);
-    return this.client.callGet<HclCategoryQueryResponse>(
-      `${this.client.catalogBaseUrl}/api/v2/categories`,
-      params,
-    );
+    return params;
   }
+
 }

--- a/packages/hcl/src/capabilities/product.capability.ts
+++ b/packages/hcl/src/capabilities/product.capability.ts
@@ -55,10 +55,10 @@ export class HclProductCapability<
   public override async getById(
     payload: ProductQueryById,
   ): Promise<Result<ProductFactoryOutput<TFactory>, NotFoundError>> {
-    const response = await this.fetchProducts({
-      partNumber: [payload.identifier.key],
-      profileName: this.config.profiles.product,
-    });
+    const response = await this.client.callGet<HclProductQueryResponse>(
+      this.getByIdUrl(payload),
+      this.getByIdPayload(payload),
+    );
 
     const products = response.contents ?? response.catalogEntryView ?? [];
     const data = products[0];
@@ -90,7 +90,12 @@ export class HclProductCapability<
   ): Promise<Result<ProductFactoryOutput<TFactory>, NotFoundError>> {
     // Resolve the URL slug to a partNumber via the HCL URL token API.
     // tokenExternalValue holds the partNumber for ProductToken entries.
-    const token = await this.fetchSlug(payload.slug);
+    const urlResponse = await this.client.callGet<HclUrlQueryResponse>(
+      this.urlsUrl(),
+      this.urlsParams(payload.slug),
+      { allowUndefined: true },
+    );
+    const token = urlResponse?.contents?.[0];
 
     if (
       !token ||
@@ -103,10 +108,10 @@ export class HclProductCapability<
       });
     }
 
-    const response = await this.fetchProducts({
-      partNumber: [token.tokenExternalValue],
-      profileName: this.config.profiles.product,
-    });
+    const response = await this.client.callGet<HclProductQueryResponse>(
+      this.getBySlugUrl(token),
+      this.getBySlugPayload(token),
+    );
 
     const products = response.contents ?? response.catalogEntryView ?? [];
     const data = products[0];
@@ -136,10 +141,10 @@ export class HclProductCapability<
   public override async getBySKU(
     payload: ProductQueryBySKU,
   ): Promise<Result<ProductFactoryOutput<TFactory>, NotFoundError>> {
-    const response = await this.fetchProducts({
-      partNumber: [payload.variant.sku],
-      profileName: this.config.profiles.product,
-    });
+    const response = await this.client.callGet<HclProductQueryResponse>(
+      this.getBySKUUrl(payload),
+      this.getBySKUPayload(payload),
+    );
 
     const products = response.contents ?? response.catalogEntryView ?? [];
     const data = products[0];
@@ -184,7 +189,10 @@ export class HclProductCapability<
 
     if (uniqueIds.length === 0) return data;
 
-    const catResp = await this.fetchCategories({ id: uniqueIds });
+    const catResp = await this.client.callGet<HclCategoryQueryResponse>(
+      this.categoriesUrl(),
+      this.categoriesParams({ id: uniqueIds }),
+    );
     const idToIdentifier = new Map(
       (catResp.contents ?? []).map((c) => [c.uniqueID, c.identifier]),
     );
@@ -193,9 +201,44 @@ export class HclProductCapability<
     return { ...data, parentCatalogGroupID: resolvedIds };
   }
 
-  protected async fetchProducts(
-    query: HclFindProductsQuery,
-  ): Promise<HclProductQueryResponse> {
+  protected getByIdUrl(_payload: ProductQueryById): string {
+    return this.productsUrl();
+  }
+
+  protected getBySlugUrl(_token: HclUrlResponse): string {
+    return this.productsUrl();
+  }
+
+  protected getBySKUUrl(_payload: ProductQueryBySKU): string {
+    return this.productsUrl();
+  }
+
+  protected getByIdPayload(payload: ProductQueryById): URLSearchParams {
+    return this.productsParams({
+      partNumber: [payload.identifier.key],
+      profileName: this.config.profiles.product,
+    });
+  }
+
+  protected getBySlugPayload(token: HclUrlResponse): URLSearchParams {
+    return this.productsParams({
+      partNumber: [token.tokenExternalValue!],
+      profileName: this.config.profiles.product,
+    });
+  }
+
+  protected getBySKUPayload(payload: ProductQueryBySKU): URLSearchParams {
+    return this.productsParams({
+      partNumber: [payload.variant.sku],
+      profileName: this.config.profiles.product,
+    });
+  }
+
+  protected productsUrl(): string {
+    return `${this.client.catalogBaseUrl}/api/v2/products`;
+  }
+
+  protected productsParams(query: HclFindProductsQuery): URLSearchParams {
     const params = new URLSearchParams();
     params.set('storeId', query.storeId ?? this.config.storeId);
     const catalogId = query.catalogId ?? this.config.catalogId;
@@ -211,15 +254,14 @@ export class HclProductCapability<
     for (const id of query.id ?? []) params.append('id', id);
     for (const pn of query.partNumber ?? []) params.append('partNumber', pn);
     for (const facet of query.facets ?? []) params.append('facet', facet);
-    return this.client.callGet<HclProductQueryResponse>(
-      `${this.client.catalogBaseUrl}/api/v2/products`,
-      params,
-    );
+    return params;
   }
 
-  protected async fetchCategories(
-    query: HclFindCategoriesQuery,
-  ): Promise<HclCategoryQueryResponse> {
+  protected categoriesUrl(): string {
+    return `${this.client.catalogBaseUrl}/api/v2/categories`;
+  }
+
+  protected categoriesParams(query: HclFindCategoriesQuery): URLSearchParams {
     const params = new URLSearchParams();
     params.set('storeId', query.storeId ?? this.config.storeId);
     const catalogId = query.catalogId ?? this.config.catalogId;
@@ -231,21 +273,17 @@ export class HclProductCapability<
     for (const id of query.id ?? []) params.append('id', id);
     for (const identifier of query.identifier ?? [])
       params.append('identifier', identifier);
-    return this.client.callGet<HclCategoryQueryResponse>(
-      `${this.client.catalogBaseUrl}/api/v2/categories`,
-      params,
-    );
+    return params;
   }
 
-  protected async fetchSlug(slug: string): Promise<HclUrlResponse | undefined> {
+  protected urlsUrl(): string {
+    return `${this.client.catalogBaseUrl}/api/v2/urls`;
+  }
+
+  protected urlsParams(slug: string): URLSearchParams {
     const params = new URLSearchParams();
     params.set('storeId', this.config.storeId);
     params.append('identifier', slug);
-    const response = await this.client.callGet<HclUrlQueryResponse>(
-      `${this.client.catalogBaseUrl}/api/v2/urls`,
-      params,
-      { allowUndefined: true },
-    );
-    return response?.contents?.[0];
+    return params;
   }
 }


### PR DESCRIPTION
…irectly

Each public capability method now calls this.client.callXxx() directly using the per-operation URL and payload extension methods. The intermediate fetchXxx wrapper layer is removed, following the perpendicular provider pattern.

- xxxUrl(...) methods return the endpoint URL (protected, overridable)
- xxxPayload(...) methods return URLSearchParams or body (protected, overridable)
- Shared helpers (fetchWcsCart, fetchCart, fetchSetPendingOrder, etc.) retained where called from multiple public methods