### PR TITLE
feat(hcl): add profile, order, and order-search capabilities

### DIFF
--- a/packages/hcl/src/capabilities/order-search.capability.ts
+++ b/packages/hcl/src/capabilities/order-search.capability.ts
@@ -1,0 +1,104 @@
+import {
+  type Cache,
+  OrderSearchCapability,
+  type OrderSearchFactory,
+  type OrderSearchFactoryOutput,
+  type OrderSearchFactoryWithOutput,
+  type OrderSearchQueryByTerm,
+  OrderSearchQueryByTermSchema,
+  OrderSearchResultSchema,
+  type OrderStatus,
+  Reactionary,
+  type RequestContext,
+  type Result,
+  success,
+} from '@reactionary/core';
+import createDebug from 'debug';
+import type { HclConfiguration } from '../schema/configuration.schema.js';
+import type { HclClient } from '../core/client.js';
+import type { HclOrderSearchFactory } from '../factories/order-search/order-search.factory.js';
+import type { HclWcsOrderListResponse } from '../schema/hcl.schema.js';
+
+const debug = createDebug('reactionary:hcl:order-search');
+
+/** All WCS non-pending statuses used when no status filter is provided. */
+const ALL_HISTORY_STATUSES = 'C,S,X,R,D,M,G,F';
+
+/** Maps a core OrderStatus to the WCS status code(s) for the byStatus endpoint. */
+function coreStatusToWcs(status: OrderStatus): string {
+  switch (status) {
+    case 'Shipped':
+      return 'S';
+    case 'Cancelled':
+      return 'X,R,D';
+    case 'ReleasedToFulfillment':
+      return 'M,G,F';
+    case 'AwaitingPayment':
+      return 'C';
+  }
+}
+
+export class HclOrderSearchCapability<
+  TFactory extends OrderSearchFactory = HclOrderSearchFactory,
+> extends OrderSearchCapability<OrderSearchFactoryOutput<TFactory>> {
+  protected config: HclConfiguration;
+  protected client: HclClient;
+  protected factory: OrderSearchFactoryWithOutput<TFactory>;
+
+  constructor(
+    cache: Cache,
+    context: RequestContext,
+    config: HclConfiguration,
+    client: HclClient,
+    factory: OrderSearchFactoryWithOutput<TFactory>,
+  ) {
+    super(cache, context);
+    this.config = config;
+    this.client = client;
+    this.factory = factory;
+  }
+
+  @Reactionary({
+    inputSchema: OrderSearchQueryByTermSchema,
+    outputSchema: OrderSearchResultSchema,
+  })
+  public async queryByTerm(
+    payload: OrderSearchQueryByTerm,
+  ): Promise<Result<OrderSearchFactoryOutput<TFactory>>> {
+    const { pageSize, pageNumber } = payload.search.paginationOptions;
+
+    const wcsStatuses = payload.search.orderStatus?.length
+      ? payload.search.orderStatus.map(coreStatusToWcs).join(',')
+      : ALL_HISTORY_STATUSES;
+
+    debug(
+      'queryByTerm statuses=%s page=%d/%d',
+      wcsStatuses,
+      pageNumber,
+      pageSize,
+    );
+
+    const data = await this.client.callGet<HclWcsOrderListResponse>(
+      this.orderByStatusUrl(wcsStatuses),
+      this.orderByStatusParams(pageSize, (pageNumber - 1) * pageSize),
+    );
+
+    return success(
+      this.factory.parseOrderSearchResult(this.context, data, payload),
+    );
+  }
+
+  protected orderByStatusUrl(statuses: string): string {
+    return `${this.client.transactionBaseUrl}/order/byStatus/${encodeURIComponent(statuses)}`;
+  }
+
+  protected orderByStatusParams(
+    maxResults: number,
+    startIndex: number,
+  ): URLSearchParams {
+    return new URLSearchParams({
+      maxResults: String(maxResults),
+      startIndex: String(startIndex),
+    });
+  }
+}

--- a/packages/hcl/src/capabilities/order.capability.ts
+++ b/packages/hcl/src/capabilities/order.capability.ts
@@ -1,0 +1,74 @@
+import {
+  type Cache,
+  type NotFoundError,
+  OrderCapability,
+  type OrderFactory,
+  type OrderFactoryOutput,
+  type OrderFactoryWithOutput,
+  type OrderQueryById,
+  OrderQueryByIdSchema,
+  OrderSchema,
+  Reactionary,
+  type RequestContext,
+  type Result,
+  error,
+  success,
+} from '@reactionary/core';
+import createDebug from 'debug';
+import type { HclConfiguration } from '../schema/configuration.schema.js';
+import type { HclClient } from '../core/client.js';
+import type { HclOrderFactory } from '../factories/order/order.factory.js';
+import type { HclWcsOrderDetailResponse } from '../schema/hcl.schema.js';
+
+const debug = createDebug('reactionary:hcl:order');
+
+export class HclOrderCapability<
+  TFactory extends OrderFactory = HclOrderFactory,
+> extends OrderCapability<OrderFactoryOutput<TFactory>> {
+  protected config: HclConfiguration;
+  protected client: HclClient;
+  protected factory: OrderFactoryWithOutput<TFactory>;
+
+  constructor(
+    cache: Cache,
+    context: RequestContext,
+    config: HclConfiguration,
+    client: HclClient,
+    factory: OrderFactoryWithOutput<TFactory>,
+  ) {
+    super(cache, context);
+    this.config = config;
+    this.client = client;
+    this.factory = factory;
+  }
+
+  @Reactionary({
+    inputSchema: OrderQueryByIdSchema,
+    outputSchema: OrderSchema,
+  })
+  public async getById(
+    payload: OrderQueryById,
+  ): Promise<Result<OrderFactoryOutput<TFactory>, NotFoundError>> {
+    debug('getById %s', payload.order.key);
+    const data = await this.client.callGet<HclWcsOrderDetailResponse>(
+      this.orderUrl(payload.order.key),
+      this.orderParams(),
+      { allowUndefined: true },
+    );
+    if (!data) {
+      return error<NotFoundError>({
+        type: 'NotFound',
+        identifier: payload.order,
+      });
+    }
+    return success(this.factory.parseOrder(this.context, data));
+  }
+
+  protected orderUrl(orderId: string): string {
+    return `${this.client.transactionBaseUrl}/order/${encodeURIComponent(orderId)}`;
+  }
+
+  protected orderParams(): URLSearchParams {
+    return new URLSearchParams({ profileName: 'IBM_getOrderDetailsByOrderId' });
+  }
+}

--- a/packages/hcl/src/capabilities/profile.capability.ts
+++ b/packages/hcl/src/capabilities/profile.capability.ts
@@ -1,0 +1,255 @@
+import {
+  type Address,
+  type Cache,
+  type NotFoundError,
+  ProfileCapability,
+  type ProfileFactory,
+  type ProfileFactoryOutput,
+  type ProfileFactoryWithOutput,
+  type ProfileMutationAddShippingAddress,
+  ProfileMutationAddShippingAddressSchema,
+  type ProfileMutationMakeShippingAddressDefault,
+  ProfileMutationMakeShippingAddressDefaultSchema,
+  type ProfileMutationRemoveShippingAddress,
+  ProfileMutationRemoveShippingAddressSchema,
+  type ProfileMutationSetBillingAddress,
+  ProfileMutationSetBillingAddressSchema,
+  type ProfileMutationUpdate,
+  ProfileMutationUpdateSchema,
+  type ProfileMutationUpdateShippingAddress,
+  ProfileMutationUpdateShippingAddressSchema,
+  type ProfileQuerySelf,
+  ProfileQueryByIdSchema,
+  ProfileSchema,
+  Reactionary,
+  type RequestContext,
+  type Result,
+  error,
+  success,
+} from '@reactionary/core';
+import createDebug from 'debug';
+import type { HclConfiguration } from '../schema/configuration.schema.js';
+import type { HclClient } from '../core/client.js';
+import type { HclProfileFactory } from '../factories/profile/profile.factory.js';
+import type {
+  HclPersonResponse,
+  HclWcsPersonContact,
+} from '../schema/hcl.schema.js';
+
+const debug = createDebug('reactionary:hcl:profile');
+
+/** NickName used to store the billing address in the WCS contact list. */
+const BILLING_NICK_NAME = 'Billing';
+
+export class HclProfileCapability<
+  TFactory extends ProfileFactory = HclProfileFactory,
+> extends ProfileCapability<ProfileFactoryOutput<TFactory>> {
+  protected config: HclConfiguration;
+  protected client: HclClient;
+  protected factory: ProfileFactoryWithOutput<TFactory>;
+
+  constructor(
+    cache: Cache,
+    context: RequestContext,
+    config: HclConfiguration,
+    client: HclClient,
+    factory: ProfileFactoryWithOutput<TFactory>,
+  ) {
+    super(cache, context);
+    this.config = config;
+    this.client = client;
+    this.factory = factory;
+  }
+
+  protected async fetchPerson(): Promise<HclPersonResponse> {
+    return this.client.callGet<HclPersonResponse>(this.personSelfUrl());
+  }
+
+  protected async fetchProfile(): Promise<ProfileFactoryOutput<TFactory>> {
+    const person = await this.fetchPerson();
+    return this.factory.parseProfile(this.context, person);
+  }
+
+  protected toWcsContact(address: Address): Partial<HclWcsPersonContact> {
+    const lines = [address.streetAddress, address.streetNumber].filter(Boolean);
+    return {
+      nickName: address.identifier.nickName,
+      firstName: address.firstName,
+      lastName: address.lastName,
+      addressLine: lines.length ? lines : undefined,
+      city: address.city,
+      stateOrProvinceName: address.region,
+      zipCode: address.postalCode,
+      country: address.countryCode,
+    };
+  }
+
+  protected personSelfUrl(): string {
+    return `${this.client.transactionBaseUrl}/person/@self`;
+  }
+
+  protected updatePersonPayload(
+    email?: string,
+    phone?: string,
+  ): { email1?: string; phone1?: string } {
+    return { email1: email, phone1: phone };
+  }
+
+  protected personContactListUrl(): string {
+    return `${this.client.transactionBaseUrl}/person/@self/contact`;
+  }
+
+  protected contactUrl(nickName: string): string {
+    return `${this.client.transactionBaseUrl}/person/@self/contact/${encodeURIComponent(nickName)}`;
+  }
+
+  protected makeShippingAddressDefaultPayload(): { primary: string } {
+    return { primary: '1' };
+  }
+
+  @Reactionary({
+    inputSchema: ProfileQueryByIdSchema,
+    outputSchema: ProfileSchema,
+  })
+  public async getById(
+    _payload: ProfileQuerySelf,
+  ): Promise<Result<ProfileFactoryOutput<TFactory>, NotFoundError>> {
+    debug('getById');
+    return success(await this.fetchProfile());
+  }
+
+  @Reactionary({
+    inputSchema: ProfileMutationUpdateSchema,
+    outputSchema: ProfileSchema,
+  })
+  public async update(
+    payload: ProfileMutationUpdate,
+  ): Promise<Result<ProfileFactoryOutput<TFactory>, NotFoundError>> {
+    debug('update %o', payload.identifier);
+    await this.client.callPut<HclPersonResponse>(
+      this.personSelfUrl(),
+      this.updatePersonPayload(payload.email, payload.phone),
+    );
+    return success(await this.fetchProfile());
+  }
+
+  @Reactionary({
+    inputSchema: ProfileMutationAddShippingAddressSchema,
+    outputSchema: ProfileSchema,
+  })
+  public async addShippingAddress(
+    payload: ProfileMutationAddShippingAddress,
+  ): Promise<Result<ProfileFactoryOutput<TFactory>, NotFoundError>> {
+    debug('addShippingAddress %s', payload.address.identifier.nickName);
+    await this.client.callPost<unknown>(
+      this.personContactListUrl(),
+      this.toWcsContact(payload.address),
+    );
+    return success(await this.fetchProfile());
+  }
+
+  @Reactionary({
+    inputSchema: ProfileMutationUpdateShippingAddressSchema,
+    outputSchema: ProfileSchema,
+  })
+  public async updateShippingAddress(
+    payload: ProfileMutationUpdateShippingAddress,
+  ): Promise<Result<ProfileFactoryOutput<TFactory>, NotFoundError>> {
+    debug('updateShippingAddress %s', payload.address.identifier.nickName);
+    try {
+      await this.client.callPut<unknown>(
+        this.contactUrl(payload.address.identifier.nickName),
+        this.toWcsContact(payload.address),
+      );
+    } catch (err) {
+      if (err instanceof Error && err.message.includes('404')) {
+        return error<NotFoundError>({
+          type: 'NotFound',
+          identifier: payload.address.identifier,
+        });
+      }
+      throw err;
+    }
+    return success(await this.fetchProfile());
+  }
+
+  @Reactionary({
+    inputSchema: ProfileMutationRemoveShippingAddressSchema,
+    outputSchema: ProfileSchema,
+  })
+  public async removeShippingAddress(
+    payload: ProfileMutationRemoveShippingAddress,
+  ): Promise<Result<ProfileFactoryOutput<TFactory>, NotFoundError>> {
+    debug('removeShippingAddress %s', payload.addressIdentifier.nickName);
+    try {
+      await this.client.callDelete(
+        this.contactUrl(payload.addressIdentifier.nickName),
+      );
+    } catch (err) {
+      if (err instanceof Error && err.message.includes('404')) {
+        return error<NotFoundError>({
+          type: 'NotFound',
+          identifier: payload.addressIdentifier,
+        });
+      }
+      throw err;
+    }
+    return success(await this.fetchProfile());
+  }
+
+  @Reactionary({
+    inputSchema: ProfileMutationMakeShippingAddressDefaultSchema,
+    outputSchema: ProfileSchema,
+  })
+  public async makeShippingAddressDefault(
+    payload: ProfileMutationMakeShippingAddressDefault,
+  ): Promise<Result<ProfileFactoryOutput<TFactory>, NotFoundError>> {
+    debug('makeShippingAddressDefault %s', payload.addressIdentifier.nickName);
+    try {
+      await this.client.callPut<unknown>(
+        this.contactUrl(payload.addressIdentifier.nickName),
+        this.makeShippingAddressDefaultPayload(),
+      );
+    } catch (err) {
+      if (err instanceof Error && err.message.includes('404')) {
+        return error<NotFoundError>({
+          type: 'NotFound',
+          identifier: payload.addressIdentifier,
+        });
+      }
+      throw err;
+    }
+    return success(await this.fetchProfile());
+  }
+
+  @Reactionary({
+    inputSchema: ProfileMutationSetBillingAddressSchema,
+    outputSchema: ProfileSchema,
+  })
+  public async setBillingAddress(
+    payload: ProfileMutationSetBillingAddress,
+  ): Promise<Result<ProfileFactoryOutput<TFactory>, NotFoundError>> {
+    debug('setBillingAddress');
+    const person = await this.fetchPerson();
+    const billingContact = (person.contact ?? []).find(
+      (c) => c.nickName === BILLING_NICK_NAME,
+    );
+    const contactData = {
+      ...this.toWcsContact(payload.address),
+      nickName: BILLING_NICK_NAME,
+    };
+
+    if (billingContact) {
+      await this.client.callPut<unknown>(
+        this.contactUrl(BILLING_NICK_NAME),
+        contactData,
+      );
+    } else {
+      await this.client.callPost<unknown>(
+        this.personContactListUrl(),
+        contactData,
+      );
+    }
+    return success(await this.fetchProfile());
+  }
+}

--- a/packages/hcl/src/core/initialize.ts
+++ b/packages/hcl/src/core/initialize.ts
@@ -2,7 +2,10 @@ import type { Cache, RequestContext } from '@reactionary/core';
 import {
   CategoryPaginatedResultSchema,
   IdentitySchema,
+  OrderSchema,
+  OrderSearchResultSchema,
   ProductSchema,
+  ProfileSchema,
 } from '@reactionary/core';
 import { HclCategorySchema } from '../schema/category.schema.js';
 import {
@@ -16,6 +19,9 @@ import {
   type HclPriceCapabilityConfig,
   type HclInventoryCapabilityConfig,
   type HclIdentityCapabilityConfig,
+  type HclProfileCapabilityConfig,
+  type HclOrderCapabilityConfig,
+  type HclOrderSearchCapabilityConfig,
 } from '../schema/capabilities.schema.js';
 import {
   HclConfigurationSchema,
@@ -32,9 +38,12 @@ import {
   HclCheckoutFactory,
   HclIdentityFactory,
   HclInventoryFactory,
+  HclOrderFactory,
+  HclOrderSearchFactory,
   HclPriceFactory,
   HclProductFactory,
   HclProductSearchFactory,
+  HclProfileFactory,
 } from '../factories/index.js';
 import { HclCartCapability } from '../capabilities/cart.capability.js';
 import { HclCheckoutCapability } from '../capabilities/checkout.capability.js';
@@ -44,6 +53,9 @@ import { HclProductSearchCapability } from '../capabilities/product-search.capab
 import { HclPriceCapability } from '../capabilities/price.capability.js';
 import { HclInventoryCapability } from '../capabilities/inventory.capability.js';
 import { HclIdentityCapability } from '../capabilities/identity.capability.js';
+import { HclProfileCapability } from '../capabilities/profile.capability.js';
+import { HclOrderCapability } from '../capabilities/order.capability.js';
+import { HclOrderSearchCapability } from '../capabilities/order-search.capability.js';
 import {
   CartIdentifierSchema,
   CartPaginatedSearchResultSchema,
@@ -224,6 +236,60 @@ export function withHclCapabilities<T extends HclCapabilities>(
           factory: new HclIdentityFactory(IdentitySchema),
           capability: (args) =>
             new HclIdentityCapability(
+              args.cache,
+              args.context,
+              args.config,
+              args.hclClient,
+              args.factory,
+            ),
+        },
+        buildCapabilityArgs,
+      );
+    }
+
+    if (caps.profile?.enabled) {
+      client.profile = resolveCapabilityWithFactory(
+        capabilities.profile as HclProfileCapabilityConfig | undefined,
+        {
+          factory: new HclProfileFactory(ProfileSchema),
+          capability: (args) =>
+            new HclProfileCapability(
+              args.cache,
+              args.context,
+              args.config,
+              args.hclClient,
+              args.factory,
+            ),
+        },
+        buildCapabilityArgs,
+      );
+    }
+
+    if (caps.order?.enabled) {
+      client.order = resolveCapabilityWithFactory(
+        capabilities.order as HclOrderCapabilityConfig | undefined,
+        {
+          factory: new HclOrderFactory(OrderSchema),
+          capability: (args) =>
+            new HclOrderCapability(
+              args.cache,
+              args.context,
+              args.config,
+              args.hclClient,
+              args.factory,
+            ),
+        },
+        buildCapabilityArgs,
+      );
+    }
+
+    if (caps.orderSearch?.enabled) {
+      client.orderSearch = resolveCapabilityWithFactory(
+        capabilities.orderSearch as HclOrderSearchCapabilityConfig | undefined,
+        {
+          factory: new HclOrderSearchFactory(OrderSearchResultSchema),
+          capability: (args) =>
+            new HclOrderSearchCapability(
               args.cache,
               args.context,
               args.config,

--- a/packages/hcl/src/core/initialize.types.ts
+++ b/packages/hcl/src/core/initialize.types.ts
@@ -8,6 +8,9 @@ import type { HclProductSearchCapability } from '../capabilities/product-search.
 import type { HclPriceCapability } from '../capabilities/price.capability.js';
 import type { HclInventoryCapability } from '../capabilities/inventory.capability.js';
 import type { HclIdentityCapability } from '../capabilities/identity.capability.js';
+import type { HclProfileCapability } from '../capabilities/profile.capability.js';
+import type { HclOrderCapability } from '../capabilities/order.capability.js';
+import type { HclOrderSearchCapability } from '../capabilities/order-search.capability.js';
 
 type OverridableCapabilityKey =
   | 'product'
@@ -17,7 +20,10 @@ type OverridableCapabilityKey =
   | 'category'
   | 'price'
   | 'inventory'
-  | 'identity';
+  | 'identity'
+  | 'profile'
+  | 'order'
+  | 'orderSearch';
 
 type EnabledCapability<TCapability> = TCapability extends { enabled: true }
   ? true
@@ -46,6 +52,9 @@ type DefaultCapabilityMap = {
   price: HclPriceCapability;
   inventory: HclInventoryCapability;
   identity: HclIdentityCapability;
+  profile: HclProfileCapability;
+  order: HclOrderCapability;
+  orderSearch: HclOrderSearchCapability;
 };
 
 type CapabilityImplementationMap<T extends HclCapabilities> = {

--- a/packages/hcl/src/factories/index.ts
+++ b/packages/hcl/src/factories/index.ts
@@ -6,3 +6,6 @@ export * from './product-search/product-search.factory.js';
 export * from './price/price.factory.js';
 export * from './inventory/inventory.factory.js';
 export * from './identity/identity.factory.js';
+export * from './profile/profile.factory.js';
+export * from './order/order.factory.js';
+export * from './order-search/order-search.factory.js';

--- a/packages/hcl/src/factories/order-search/order-search.factory.ts
+++ b/packages/hcl/src/factories/order-search/order-search.factory.ts
@@ -1,0 +1,96 @@
+import type {
+  AnyOrderSearchResultSchema,
+  Currency,
+  IdentityIdentifier,
+  MonetaryAmount,
+  OrderInventoryStatus,
+  OrderSearchFactory,
+  OrderSearchIdentifier,
+  OrderSearchQueryByTerm,
+  OrderSearchResult,
+  OrderSearchResultItem,
+  OrderSearchResultSchema,
+  OrderStatus,
+  RequestContext,
+} from '@reactionary/core';
+import type * as z from 'zod';
+import type {
+  HclWcsCartResponse,
+  HclWcsOrderListResponse,
+} from '../../schema/hcl.schema.js';
+
+function mapWcsOrderStatus(status: string): OrderStatus {
+  switch (status) {
+    case 'S':
+      return 'Shipped';
+    case 'X':
+    case 'R':
+    case 'D':
+      return 'Cancelled';
+    case 'M':
+    case 'G':
+    case 'F':
+      return 'ReleasedToFulfillment';
+    default:
+      return 'AwaitingPayment';
+  }
+}
+
+export class HclOrderSearchFactory<
+  TOrderSearchResultSchema extends
+    AnyOrderSearchResultSchema = typeof OrderSearchResultSchema,
+> implements OrderSearchFactory<TOrderSearchResultSchema>
+{
+  public readonly orderSearchResultSchema: TOrderSearchResultSchema;
+
+  constructor(orderSearchResultSchema: TOrderSearchResultSchema) {
+    this.orderSearchResultSchema = orderSearchResultSchema;
+  }
+
+  public parseOrderSearchResult(
+    context: RequestContext,
+    data: HclWcsOrderListResponse,
+    query: OrderSearchQueryByTerm,
+  ): z.output<TOrderSearchResultSchema> {
+    const items = (data.Order ?? []).map((o) =>
+      this.parseOrderSearchResultItem(context, o),
+    );
+    const totalCount = Number(data.recordSetTotal ?? items.length);
+    const { pageSize, pageNumber } = query.search.paginationOptions;
+
+    const result = {
+      identifier: { ...query.search } satisfies OrderSearchIdentifier,
+      items,
+      totalCount,
+      pageSize,
+      pageNumber,
+      totalPages: Math.ceil(totalCount / Math.max(1, pageSize)),
+    } satisfies OrderSearchResult;
+
+    return this.orderSearchResultSchema.parse(result);
+  }
+
+  protected parseOrderSearchResultItem(
+    _context: RequestContext,
+    item: HclWcsCartResponse,
+  ): OrderSearchResultItem {
+    const orderStatus = mapWcsOrderStatus(item.orderStatus ?? '');
+    const inventoryStatus: OrderInventoryStatus =
+      orderStatus === 'Shipped' ? 'Allocated' : 'NotAllocated';
+    const userId: IdentityIdentifier = { userId: item.buyerId ?? '' };
+    const totalAmount: MonetaryAmount = {
+      value: Number(item.grandTotal ?? '0'),
+      currency: (item.grandTotalCurrency ?? 'USD') as Currency,
+    };
+
+    return {
+      identifier: { key: item.orderId },
+      userId,
+      customerName: '',
+      orderDate: item.lastUpdateDate ?? '',
+      orderStatus,
+      inventoryStatus,
+      totalAmount,
+    } satisfies OrderSearchResultItem;
+  }
+}

--- a/packages/hcl/src/factories/order/order.factory.ts
+++ b/packages/hcl/src/factories/order/order.factory.ts
@@ -1,0 +1,188 @@
+import type {
+  AnyOrderSchema,
+  CostBreakDown,
+  Currency,
+  IdentityIdentifier,
+  ItemCostBreakdown,
+  Order,
+  OrderFactory,
+  OrderInventoryStatus,
+  OrderItem,
+  OrderSchema,
+  OrderStatus,
+  PaymentInstruction,
+  PaymentMethodIdentifier,
+  RequestContext,
+} from '@reactionary/core';
+import type * as z from 'zod';
+import type {
+  HclWcsOrderDetailResponse,
+  HclWcsOrderItem,
+  HclWcsPaymentInstruction,
+} from '../../schema/hcl.schema.js';
+
+function mapWcsOrderStatus(status: string): OrderStatus {
+  switch (status) {
+    case 'S':
+      return 'Shipped';
+    case 'X':
+    case 'R':
+    case 'D':
+      return 'Cancelled';
+    case 'M':
+    case 'G':
+    case 'F':
+      return 'ReleasedToFulfillment';
+    default:
+      // 'P' (pending), 'I' (initial), 'W' (awaiting approval), 'N' (no inventory), etc.
+      return 'AwaitingPayment';
+  }
+}
+
+export class HclOrderFactory<
+  TOrderSchema extends AnyOrderSchema = typeof OrderSchema,
+> implements OrderFactory<TOrderSchema>
+{
+  public readonly orderSchema: TOrderSchema;
+
+  constructor(orderSchema: TOrderSchema) {
+    this.orderSchema = orderSchema;
+  }
+
+  public parseOrder(
+    context: RequestContext,
+    data: HclWcsOrderDetailResponse,
+  ): z.output<TOrderSchema> {
+    const currency = (data.grandTotalCurrency ??
+      data.totalProductPriceCurrency ??
+      'USD') as Currency;
+
+    const orderStatus = mapWcsOrderStatus(data.orderStatus ?? '');
+    const inventoryStatus: OrderInventoryStatus =
+      orderStatus === 'Shipped' ? 'Allocated' : 'NotAllocated';
+
+    const userId: IdentityIdentifier = { userId: data.buyerId ?? '' };
+
+    const result = {
+      identifier: { key: data.orderId },
+      userId,
+      items: (data.orderItem ?? []).map((item) =>
+        this.parseOrderItem(context, item, currency),
+      ),
+      price: this.parseCostBreakdown(context, data, currency),
+      orderStatus,
+      inventoryStatus,
+      paymentInstructions: (data.paymentInstruction ?? []).map((pi) =>
+        this.parsePaymentInstruction(context, pi, currency),
+      ),
+      shippingAddress: data.x_shippingAddress
+        ? {
+            identifier: {
+              nickName: data.x_shippingAddress.nickName ?? '',
+            },
+            firstName: data.x_shippingAddress.firstName ?? '',
+            lastName: data.x_shippingAddress.lastName ?? '',
+            streetAddress:
+              data.x_shippingAddress.addressLine?.[0] ??
+              data.x_shippingAddress.address1 ??
+              '',
+            streetNumber: data.x_shippingAddress.addressLine?.[1] ?? '',
+            city: data.x_shippingAddress.city ?? '',
+            region: data.x_shippingAddress.state ?? '',
+            postalCode: data.x_shippingAddress.zipCode ?? '',
+            countryCode: data.x_shippingAddress.country ?? '',
+          }
+        : undefined,
+      billingAddress: data.x_billingAddress
+        ? {
+            identifier: {
+              nickName: data.x_billingAddress.nickName ?? '',
+            },
+            firstName: data.x_billingAddress.firstName ?? '',
+            lastName: data.x_billingAddress.lastName ?? '',
+            streetAddress:
+              data.x_billingAddress.addressLine?.[0] ??
+              data.x_billingAddress.address1 ??
+              '',
+            streetNumber: data.x_billingAddress.addressLine?.[1] ?? '',
+            city: data.x_billingAddress.city ?? '',
+            region: data.x_billingAddress.state ?? '',
+            postalCode: data.x_billingAddress.zipCode ?? '',
+            countryCode: data.x_billingAddress.country ?? '',
+          }
+        : undefined,
+    } satisfies Order;
+
+    return this.orderSchema.parse(result);
+  }
+
+  protected parseOrderItem(
+    _context: RequestContext,
+    item: HclWcsOrderItem,
+    defaultCurrency: Currency,
+  ): OrderItem {
+    const currency = (item.currency ?? defaultCurrency) as Currency;
+    const price: ItemCostBreakdown = {
+      unitPrice: { value: Number(item.unitPrice), currency },
+      totalPrice: { value: Number(item.orderItemPrice), currency },
+      unitDiscount: { value: 0, currency },
+      totalDiscount: { value: 0, currency },
+    };
+
+    return {
+      identifier: { key: item.orderItemId },
+      variant: { sku: item.partNumber },
+      quantity: Number(item.quantity),
+      price,
+      inventoryStatus: 'Allocated',
+    } satisfies OrderItem;
+  }
+
+  protected parseCostBreakdown(
+    _context: RequestContext,
+    data: HclWcsOrderDetailResponse,
+    currency: Currency,
+  ): CostBreakDown {
+    return {
+      grandTotal: { value: Number(data.grandTotal ?? '0'), currency },
+      totalProductPrice: {
+        value: Number(data.totalProductPrice ?? '0'),
+        currency,
+      },
+      totalShipping: {
+        value: Number(data.totalShippingCharge ?? '0'),
+        currency,
+      },
+      totalTax: { value: Number(data.totalSalesTax ?? '0'), currency },
+      totalDiscount: {
+        value: Math.abs(Number(data.totalAdjustment ?? '0')),
+        currency,
+      },
+      totalSurcharge: { value: 0, currency },
+    };
+  }
+
+  protected parsePaymentInstruction(
+    _context: RequestContext,
+    pi: HclWcsPaymentInstruction,
+    defaultCurrency: Currency,
+  ): PaymentInstruction {
+    const currency = (pi.currency ?? defaultCurrency) as Currency;
+    const paymentMethod: PaymentMethodIdentifier = {
+      method: pi.payMethodId,
+      name: pi.piDescription ?? pi.payMethodId,
+      paymentProcessor: pi.payMethodId,
+    };
+
+    return {
+      identifier: { key: pi.piId },
+      amount: { value: Number(pi.piAmount ?? '0'), currency },
+      paymentMethod,
+      protocolData: (pi.protocolData ?? []).map((pd) => ({
+        key: pd.name,
+        value: pd.value,
+      })),
+      status: 'pending',
+    } satisfies PaymentInstruction;
+  }
+}

--- a/packages/hcl/src/factories/profile/profile.factory.ts
+++ b/packages/hcl/src/factories/profile/profile.factory.ts
@@ -1,0 +1,85 @@
+import type {
+  Address,
+  AnyProfileSchema,
+  Profile,
+  ProfileFactory,
+  ProfileSchema,
+  RequestContext,
+} from '@reactionary/core';
+import type * as z from 'zod';
+import type {
+  HclPersonResponse,
+  HclWcsPersonContact,
+} from '../../schema/hcl.schema.js';
+
+/** NickName reserved for the billing address in the WCS contact list. */
+const BILLING_NICK_NAME = 'Billing';
+
+export class HclProfileFactory<
+  TProfileSchema extends AnyProfileSchema = typeof ProfileSchema,
+> implements ProfileFactory<TProfileSchema>
+{
+  public readonly profileSchema: TProfileSchema;
+
+  constructor(profileSchema: TProfileSchema) {
+    this.profileSchema = profileSchema;
+  }
+
+  public parseProfile(
+    context: RequestContext,
+    data: HclPersonResponse,
+  ): z.output<TProfileSchema> {
+    const contacts = data.contact ?? [];
+
+    const billingContact = contacts.find(
+      (c) => c.nickName === BILLING_NICK_NAME,
+    );
+    const shippingContacts = contacts.filter(
+      (c) => c.nickName !== BILLING_NICK_NAME,
+    );
+
+    // The contact marked primary='1' is the default shipping address;
+    // fall back to the first non-billing contact when none is marked.
+    const defaultShipping =
+      shippingContacts.find((c) => c.primary === '1') ?? shippingContacts[0];
+    const alternates = shippingContacts.filter((c) => c !== defaultShipping);
+
+    const result = {
+      identifier: { userId: data.userId },
+      email: data.email1 ?? data.logonId ?? '',
+      phone: data.phone1 ?? '',
+      emailVerified: false,
+      phoneVerified: false,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      billingAddress: billingContact
+        ? this.parseAddress(context, billingContact)
+        : undefined,
+      shippingAddress: defaultShipping
+        ? this.parseAddress(context, defaultShipping)
+        : undefined,
+      alternateShippingAddresses: alternates.map((c) =>
+        this.parseAddress(context, c),
+      ),
+    } satisfies Profile;
+
+    return this.profileSchema.parse(result);
+  }
+
+  protected parseAddress(
+    _context: RequestContext,
+    contact: HclWcsPersonContact,
+  ): Address {
+    return {
+      identifier: { nickName: contact.nickName },
+      firstName: contact.firstName ?? '',
+      lastName: contact.lastName ?? '',
+      streetAddress: contact.addressLine?.[0] ?? contact.address1 ?? '',
+      streetNumber: contact.addressLine?.[1] ?? '',
+      city: contact.city ?? '',
+      region: contact.stateOrProvinceName ?? '',
+      postalCode: contact.zipCode ?? '',
+      countryCode: contact.country ?? '',
+    };
+  }
+}

--- a/packages/hcl/src/index.ts
+++ b/packages/hcl/src/index.ts
@@ -14,3 +14,6 @@ export * from './capabilities/product-search.capability.js';
 export * from './capabilities/price.capability.js';
 export * from './capabilities/inventory.capability.js';
 export * from './capabilities/identity.capability.js';
+export * from './capabilities/profile.capability.js';
+export * from './capabilities/order.capability.js';
+export * from './capabilities/order-search.capability.js';

--- a/packages/hcl/src/schema/capabilities.schema.ts
+++ b/packages/hcl/src/schema/capabilities.schema.ts
@@ -16,6 +16,12 @@ import type {
   InventoryFactory,
   InventoryFactoryWithOutput,
   InventoryCapability,
+  OrderFactory,
+  OrderFactoryWithOutput,
+  OrderCapability,
+  OrderSearchFactory,
+  OrderSearchFactoryWithOutput,
+  OrderSearchCapability,
   PriceFactory,
   PriceFactoryWithOutput,
   PriceCapability,
@@ -25,6 +31,9 @@ import type {
   ProductSearchFactory,
   ProductSearchFactoryWithOutput,
   ProductSearchCapability,
+  ProfileFactory,
+  ProfileFactoryWithOutput,
+  ProfileCapability,
 } from '@reactionary/core';
 import { CapabilitiesSchema } from '@reactionary/core';
 import type { HclConfiguration } from './configuration.schema.js';
@@ -46,6 +55,9 @@ export const HclCapabilitiesSchema = CapabilitiesSchema.pick({
   inventory: true,
   identity: true,
   productSearch: true,
+  profile: true,
+  order: true,
+  orderSearch: true,
 })
   .extend({
     cart: OverridableCapabilitySchema.optional(),
@@ -56,6 +68,9 @@ export const HclCapabilitiesSchema = CapabilitiesSchema.pick({
     inventory: OverridableCapabilitySchema.optional(),
     identity: OverridableCapabilitySchema.optional(),
     productSearch: OverridableCapabilitySchema.optional(),
+    profile: OverridableCapabilitySchema.optional(),
+    order: OverridableCapabilitySchema.optional(),
+    orderSearch: OverridableCapabilitySchema.optional(),
   })
   .partial();
 
@@ -117,4 +132,19 @@ export type HclProductSearchCapabilityConfig = HclCapabilityConfig<
 export type HclIdentityCapabilityConfig = HclCapabilityConfig<
   IdentityFactoryWithOutput<IdentityFactory>,
   IdentityCapability
+>;
+
+export type HclProfileCapabilityConfig = HclCapabilityConfig<
+  ProfileFactoryWithOutput<ProfileFactory>,
+  ProfileCapability
+>;
+
+export type HclOrderCapabilityConfig = HclCapabilityConfig<
+  OrderFactoryWithOutput<OrderFactory>,
+  OrderCapability
+>;
+
+export type HclOrderSearchCapabilityConfig = HclCapabilityConfig<
+  OrderSearchFactoryWithOutput<OrderSearchFactory>,
+  OrderSearchCapability
 >;

--- a/packages/hcl/src/schema/hcl.schema.ts
+++ b/packages/hcl/src/schema/hcl.schema.ts
@@ -446,6 +446,32 @@ export interface HclWcsIdentityResponse {
 }
 
 /**
+ * A single entry in a WCS person address book (contact list).
+ * Returned as part of the GET /person/@self response (contact[] field)
+ * and used for POST/PUT /person/@self/contact operations.
+ */
+export interface HclWcsPersonContact {
+  /** Unique identifier / display name for this address (e.g. 'Home', 'Work', 'Billing'). */
+  nickName: string;
+  firstName?: string;
+  lastName?: string;
+  /** Street address lines. Index 0 = street, index 1 = apartment / second line. */
+  addressLine?: string[];
+  /** Alternative single-field address (some WCS endpoint variants). */
+  address1?: string;
+  city?: string;
+  stateOrProvinceName?: string;
+  zipCode?: string;
+  /** ISO country code, e.g. 'US'. */
+  country?: string;
+  phone1?: string;
+  email1?: string;
+  /** '1' marks this as the default / primary shipping address. */
+  primary?: string;
+  addressType?: string;
+}
+
+/**
  * Response from GET /wcs/resources/store/{storeId}/person/@self.
  * Only the fields we use are typed; the full WCS schema has many more.
  */
@@ -457,9 +483,12 @@ export interface HclPersonResponse {
   email1?: string;
   firstName?: string;
   lastName?: string;
+  phone1?: string;
   resourceName?: string;
   /** Organization ID. `-2000` indicates the default anonymous org. */
   orgizationId?: string;
+  /** Address book entries embedded in the person/@self response. */
+  contact?: HclWcsPersonContact[];
 }
 
 // ---------------------------------------------------------------------------
@@ -662,4 +691,42 @@ export interface HclWcsCreateOrderResponse {
   outOrderId: string;
   redirecturl?: string;
   viewTaskName?: string;
+}
+
+/**
+ * A full order as returned by GET /wcs/resources/store/{storeId}/order/{orderId}.
+ * Extends the cart response shape with the `placedDate` field that is only
+ * present on placed (non-active) orders.
+ */
+export interface HclWcsOrderDetailResponse extends HclWcsCartResponse {
+  /** Date/time when the order was placed, e.g. '2024-01-15T10:30:00.000Z'. */
+  placedDate?: string;
+}
+
+/**
+ * A single summary entry in a GET /wcs/resources/store/{storeId}/order/@history response.
+ * Contains only the fields available in the history list; use getById for full detail.
+ */
+export interface HclWcsOrderHistoryItem {
+  orderId: string;
+  /** WCS order status code, e.g. 'P', 'M', 'S', 'X'. */
+  status: string;
+  placedDate?: string;
+  grandTotal?: string;
+  grandTotalCurrency?: string;
+  totalProductPrice?: string;
+  orderDescription?: string;
+  buyerDistinguishedName?: string;
+}
+
+/**
+ * Top-level response from GET /wcs/resources/store/{storeId}/order/@history.
+ * Returns a paginated list of the buyer's past orders.
+ */
+export interface HclWcsOrderHistoryResponse {
+  Order?: HclWcsOrderHistoryItem[];
+  recordSetTotal?: string;
+  recordSetCount?: string;
+  recordSetStartNumber?: string;
+  recordSetComplete?: string;
 }

--- a/packages/hcl/src/test/order-search.capability.spec.ts
+++ b/packages/hcl/src/test/order-search.capability.spec.ts
@@ -1,0 +1,89 @@
+import 'dotenv/config';
+import type { RequestContext } from '@reactionary/core';
+import {
+  NoOpCache,
+  OrderSearchResultSchema,
+  createInitialRequestContext,
+} from '@reactionary/core';
+import { describe, expect, it, beforeEach, beforeAll } from 'vitest';
+import { HclOrderSearchCapability } from '../capabilities/order-search.capability.js';
+import { HclOrderSearchFactory } from '../factories/index.js';
+import { HclClient } from '../core/client.js';
+import type { HclWcsIdentityResponse } from '../schema/hcl.schema.js';
+import { getHclTestConfiguration } from './test-utils.js';
+
+const hasCredentials = !!process.env['HCL_USER'] && !!process.env['HCL_PASS'];
+
+describe.skipIf(!hasCredentials)('HCL Order Search Capability', () => {
+  let provider: HclOrderSearchCapability;
+  let reqCtx: RequestContext;
+  let client: HclClient;
+
+  beforeAll(async () => {
+    reqCtx = createInitialRequestContext();
+    const config = getHclTestConfiguration();
+    client = new HclClient(config, reqCtx);
+
+    const loginResponse = await client.callPost<HclWcsIdentityResponse>(
+      `${client.transactionBaseUrl}/loginidentity`,
+      {
+        logonId: process.env['HCL_USER'],
+        logonPassword: process.env['HCL_PASS'],
+      },
+    );
+    reqCtx.session['hcl.WCToken'] = loginResponse.WCToken;
+    reqCtx.session['hcl.WCTrustedToken'] = loginResponse.WCTrustedToken;
+    reqCtx.session['hcl.userId'] = loginResponse.userId;
+    reqCtx.session['hcl.identityType'] = 'registered';
+  });
+
+  beforeEach(() => {
+    const config = getHclTestConfiguration();
+    provider = new HclOrderSearchCapability(
+      new NoOpCache(),
+      reqCtx,
+      config,
+      client,
+      new HclOrderSearchFactory(OrderSearchResultSchema),
+    );
+  });
+
+  it('should return order history for authenticated user', async () => {
+    const result = await provider.queryByTerm({
+      search: {
+        term: '',
+        paginationOptions: { pageSize: 10, pageNumber: 1 },
+      },
+    });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    expect(result.value.items).toBeDefined();
+    expect(Array.isArray(result.value.items)).toBe(true);
+  });
+
+  it('should return page 2 of order history', async () => {
+    const result = await provider.queryByTerm({
+      search: {
+        term: '',
+        paginationOptions: { pageSize: 5, pageNumber: 2 },
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('should return empty items when no orders exist', async () => {
+    // Request a page far into the future to get empty results
+    const result = await provider.queryByTerm({
+      search: {
+        term: '',
+        paginationOptions: { pageSize: 10, pageNumber: 9999 },
+      },
+    });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    expect(result.value.items).toBeDefined();
+    expect(Array.isArray(result.value.items)).toBe(true);
+  });
+});

--- a/packages/hcl/src/test/order.capability.spec.ts
+++ b/packages/hcl/src/test/order.capability.spec.ts
@@ -1,0 +1,87 @@
+import 'dotenv/config';
+import type { RequestContext } from '@reactionary/core';
+import {
+  NoOpCache,
+  OrderSchema,
+  createInitialRequestContext,
+} from '@reactionary/core';
+import { describe, expect, it, beforeEach, beforeAll } from 'vitest';
+import { HclOrderCapability } from '../capabilities/order.capability.js';
+import { HclOrderFactory } from '../factories/index.js';
+import { HclClient } from '../core/client.js';
+import type {
+  HclWcsIdentityResponse,
+  HclWcsOrderListResponse,
+} from '../schema/hcl.schema.js';
+import { getHclTestConfiguration } from './test-utils.js';
+
+const hasCredentials = !!process.env['HCL_USER'] && !!process.env['HCL_PASS'];
+
+describe.skipIf(!hasCredentials)('HCL Order Capability', () => {
+  let provider: HclOrderCapability;
+  let reqCtx: RequestContext;
+  let client: HclClient;
+  let orderId: string | undefined;
+
+  beforeAll(async () => {
+    reqCtx = createInitialRequestContext();
+    const config = getHclTestConfiguration();
+    client = new HclClient(config, reqCtx);
+
+    const loginResponse = await client.callPost<HclWcsIdentityResponse>(
+      `${client.transactionBaseUrl}/loginidentity`,
+      {
+        logonId: process.env['HCL_USER'],
+        logonPassword: process.env['HCL_PASS'],
+      },
+    );
+    reqCtx.session['hcl.WCToken'] = loginResponse.WCToken;
+    reqCtx.session['hcl.WCTrustedToken'] = loginResponse.WCTrustedToken;
+    reqCtx.session['hcl.userId'] = loginResponse.userId;
+    reqCtx.session['hcl.identityType'] = 'registered';
+
+    // Use env-provided order id, or look up the first one from history
+    if (process.env['HCL_ORDER_ID']) {
+      orderId = process.env['HCL_ORDER_ID'];
+    } else {
+      const history = await client.callGet<HclWcsOrderListResponse>(
+        `${client.transactionBaseUrl}/order/byStatus/C,S,X,R,D,M,G,F`,
+        new URLSearchParams({ maxResults: '1', startIndex: '0' }),
+      );
+      orderId = history.Order?.[0]?.orderId;
+    }
+  });
+
+  beforeEach(() => {
+    const config = getHclTestConfiguration();
+    provider = new HclOrderCapability(
+      new NoOpCache(),
+      reqCtx,
+      config,
+      client,
+      new HclOrderFactory(OrderSchema),
+    );
+  });
+
+  it('should return an order by id', async () => {
+    if (!orderId) {
+      console.warn('No order id available — skipping getById test');
+      return;
+    }
+
+    const result = await provider.getById({ order: { key: orderId } });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    expect(result.value.identifier.key).toBe(orderId);
+  });
+
+  it('should return NotFound for unknown order id', async () => {
+    const result = await provider.getById({
+      order: { key: 'definitely-not-real-99999999' },
+    });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.type).toBe('NotFound');
+  });
+});

--- a/packages/hcl/src/test/profile.capability.spec.ts
+++ b/packages/hcl/src/test/profile.capability.spec.ts
@@ -1,0 +1,187 @@
+import 'dotenv/config';
+import type { RequestContext } from '@reactionary/core';
+import {
+  NoOpCache,
+  ProfileSchema,
+  createInitialRequestContext,
+} from '@reactionary/core';
+import { describe, expect, it, beforeEach, beforeAll } from 'vitest';
+import { HclProfileCapability } from '../capabilities/profile.capability.js';
+import { HclProfileFactory } from '../factories/index.js';
+import { HclClient } from '../core/client.js';
+import type { HclWcsIdentityResponse } from '../schema/hcl.schema.js';
+import { getHclTestConfiguration } from './test-utils.js';
+
+const hasCredentials = !!process.env['HCL_USER'] && !!process.env['HCL_PASS'];
+
+describe.skipIf(!hasCredentials)('HCL Profile Capability', () => {
+  let provider: HclProfileCapability;
+  let reqCtx: RequestContext;
+  let client: HclClient;
+
+  beforeAll(async () => {
+    reqCtx = createInitialRequestContext();
+    const config = getHclTestConfiguration();
+    client = new HclClient(config, reqCtx);
+
+    // Login with registered user
+    const loginResponse = await client.callPost<HclWcsIdentityResponse>(
+      `${client.transactionBaseUrl}/loginidentity`,
+      {
+        logonId: process.env['HCL_USER'],
+        logonPassword: process.env['HCL_PASS'],
+      },
+    );
+    reqCtx.session['hcl.WCToken'] = loginResponse.WCToken;
+    reqCtx.session['hcl.WCTrustedToken'] = loginResponse.WCTrustedToken;
+    reqCtx.session['hcl.userId'] = loginResponse.userId;
+    reqCtx.session['hcl.identityType'] = 'registered';
+  });
+
+  beforeEach(() => {
+    const config = getHclTestConfiguration();
+    provider = new HclProfileCapability(
+      new NoOpCache(),
+      reqCtx,
+      config,
+      client,
+      new HclProfileFactory(ProfileSchema),
+    );
+  });
+
+  it('should return the authenticated user profile', async () => {
+    const result = await provider.getById({});
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    expect(result.value.email).toBeTruthy();
+  });
+
+  it('should update profile email and phone', async () => {
+    const profileResult = await provider.getById({});
+    expect(profileResult.success).toBe(true);
+    if (!profileResult.success) return;
+
+    const original = profileResult.value;
+
+    const updated = await provider.update({
+      identifier: original.identifier,
+      email: original.email,
+      phone: original.phone ?? '',
+    });
+    expect(updated.success).toBe(true);
+  });
+
+  it('should add a shipping address', async () => {
+    const result = await provider.addShippingAddress({
+      address: {
+        identifier: { nickName: 'TestAddr_' + Date.now() },
+        firstName: 'Test',
+        lastName: 'User',
+        streetAddress: 'Test Street 1',
+        city: 'Helsinki',
+        postalCode: '00100',
+        countryCode: 'FI',
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('should update an existing shipping address', async () => {
+    const profileResult = await provider.getById({});
+    expect(profileResult.success).toBe(true);
+    if (!profileResult.success) return;
+
+    const addresses = profileResult.value.shippingAddresses ?? [];
+    if (addresses.length === 0) {
+      console.warn('No shipping addresses to update — skipping');
+      return;
+    }
+
+    const addr = addresses[0];
+    const result = await provider.updateShippingAddress({
+      address: { ...addr, city: 'Espoo' },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('should return NotFound when updating a non-existent address', async () => {
+    const result = await provider.updateShippingAddress({
+      address: {
+        identifier: { nickName: 'DoesNotExist_' + Date.now() },
+        firstName: 'Ghost',
+        lastName: 'User',
+        streetAddress: 'Nowhere',
+        city: 'Void',
+        postalCode: '00000',
+        countryCode: 'FI',
+      },
+    });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.type).toBe('NotFound');
+  });
+
+  it('should remove a shipping address', async () => {
+    // Add one first so we have something to remove
+    const nick = 'ToDelete_' + Date.now();
+    const addResult = await provider.addShippingAddress({
+      address: {
+        identifier: { nickName: nick },
+        firstName: 'Delete',
+        lastName: 'Me',
+        streetAddress: 'Temp St 1',
+        city: 'Helsinki',
+        postalCode: '00100',
+        countryCode: 'FI',
+      },
+    });
+    expect(addResult.success).toBe(true);
+
+    const removeResult = await provider.removeShippingAddress({
+      addressIdentifier: { nickName: nick },
+    });
+    expect(removeResult.success).toBe(true);
+  });
+
+  it('should return NotFound when removing a non-existent address', async () => {
+    const result = await provider.removeShippingAddress({
+      addressIdentifier: { nickName: 'DoesNotExist_' + Date.now() },
+    });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.type).toBe('NotFound');
+  });
+
+  it('should set a default shipping address', async () => {
+    const profileResult = await provider.getById({});
+    expect(profileResult.success).toBe(true);
+    if (!profileResult.success) return;
+
+    const addresses = profileResult.value.shippingAddresses ?? [];
+    if (addresses.length === 0) {
+      console.warn('No shipping addresses to make default — skipping');
+      return;
+    }
+
+    const result = await provider.makeShippingAddressDefault({
+      addressIdentifier: addresses[0].identifier,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('should set the billing address (upsert)', async () => {
+    const result = await provider.setBillingAddress({
+      address: {
+        identifier: { nickName: 'Billing' },
+        firstName: 'Billing',
+        lastName: 'User',
+        streetAddress: 'Billing Ave 1',
+        city: 'Helsinki',
+        postalCode: '00100',
+        countryCode: 'FI',
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+});


### PR DESCRIPTION
- Add HclProfileCapability with full CRUD for addresses (shipping & billing)
- Add HclOrderCapability with getById using IBM_getOrderDetailsByOrderId profile
- Add HclOrderSearchCapability querying order/byStatus with status filter support
- Add corresponding factories: HclProfileFactory, HclOrderFactory, HclOrderSearchFactory
- Wire all three into initialize.ts, capabilities.schema.ts, initialize.types.ts
- Add integration test specs for all three capabilities
- All URL and payload logic extracted to protected extension point methods