### PR TITLE
feat(hcl): add analytics, product-associations, product-recommendations, and personalization-profile capabilities

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -35,3 +35,14 @@ HCL_STORE_ID=
 # Optional — omit if not needed
 
 HCL_CATALOG_ID=
+
+# Set to the username/password of a registered test user to run login tests
+
+HCL_USER=
+HCL_PASS=
+
+# Set to any non-empty value when the Reactionary\_\* marketing espots are
+
+# configured on the target HCL server to run espot/recommendation tests
+
+HCL_ESPOTS_CONFIGURED=

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,303 @@
+# Reactionary — Copilot Instructions
+
+## Project structure
+
+This is an Nx monorepo of TypeScript packages that implement a unified commerce abstraction layer called **Reactionary**.
+
+| Path                      | Package                      | Purpose                                                            |
+| ------------------------- | ---------------------------- | ------------------------------------------------------------------ |
+| `packages/core/`          | `@reactionary/core`          | Shared types, schemas, base capability classes, factory interfaces |
+| `packages/hcl/`           | `@reactionary/hcl`           | HCL Commerce provider — the primary provider package               |
+| `packages/fake/`          | `@reactionary/fake`          | In-memory fake for testing consumers                               |
+| `packages/algolia/`       | `@reactionary/algolia`       | Algolia search adapter                                             |
+| `packages/commercetools/` | `@reactionary/commercetools` | commercetools adapter                                              |
+| `packages/medusa/`        | `@reactionary/medusa`        | Medusa adapter                                                     |
+
+Use `packages/medusa/` as the reference when scaffolding a new provider package — it has the cleanest structure.
+
+---
+
+## Build, lint, and test commands
+
+```bash
+# Build HCL package (also builds core)
+npx nx build hcl
+
+# Lint
+npx nx lint hcl
+
+# Type-check lib only
+npx tsc -p packages/hcl/tsconfig.json --noEmit
+
+# Type-check tests too (spec tsconfig includes test files)
+npx tsc -p packages/hcl/tsconfig.spec.json --noEmit
+
+# Run integration tests (requires .env with live credentials)
+source .env && npx vitest run --config packages/hcl/vitest.config.mts
+```
+
+All source files are ESM-only. Always use `.js` extensions in imports even for `.ts` sources.
+
+---
+
+## HCL Commerce architecture
+
+HCL Commerce exposes two distinct service tiers with separate base URLs:
+
+| Tier                    | `HclClient` property        | URL pattern                              | Purpose                                                      |
+| ----------------------- | --------------------------- | ---------------------------------------- | ------------------------------------------------------------ |
+| Query Service           | `client.catalogBaseUrl`     | `{apiUrl}/search/resources`              | Product catalogue, categories, search — read-only, cacheable |
+| WCS Transaction Service | `client.transactionBaseUrl` | `{apiUrl}/wcs/resources/store/{storeId}` | Cart, checkout, identity, pricing, espots, events — stateful |
+
+Always call the correct tier. Mixing them causes auth or path errors.
+
+---
+
+## Capability pattern
+
+Each capability class:
+
+1. Extends a base class from `@reactionary/core` (e.g. `ProductRecommendationsCapability`)
+2. Is generic over `TFactory` — the factory that parses API responses
+3. Receives `cache`, `context`, `config`, `client`, and `factory` via constructor
+4. Annotates public methods with `@Reactionary({ inputSchema, outputSchema })` for validation and caching
+
+```typescript
+export class HclFooCapability<TFactory extends FooFactory = HclFooFactory> extends FooCapability<FooFactoryOutput<TFactory>> {
+  constructor(
+    cache: Cache,
+    context: RequestContext,
+    protected readonly config: HclConfiguration,
+    protected readonly client: HclClient,
+    protected readonly factory: FooFactoryWithOutput<TFactory>,
+  ) {
+    super(cache, context);
+  }
+
+  @Reactionary({ inputSchema: FooQuerySchema, outputSchema: FooSchema })
+  public override async getFoo(query: FooQuery): Promise<Result<FooFactoryOutput<TFactory>>> {
+    const response = await this.client.callGet<HclFooResponse>(this.getFooUrl(query), this.getFooParams(query));
+    return success(this.factory.parseFoo(this.context, response));
+  }
+
+  protected getFooUrl(query: FooQuery): string {
+    return `${this.client.catalogBaseUrl}/api/v2/foo/${encodeURIComponent(query.key)}`;
+  }
+
+  protected getFooParams(query: FooQuery): URLSearchParams {
+    const params = new URLSearchParams();
+    params.set('storeId', this.config.storeId);
+    return params;
+  }
+}
+```
+
+**Capabilities without factory output** (e.g. `HclAnalyticsCapability`) do not use a `TFactory` generic — they fire-and-forget and return a fixed `AnalyticsResult` type.
+
+---
+
+## Extension point pattern (URL + params/payload)
+
+**Every capability method that calls an external API must expose the URL and parameters as protected overridable methods.** This is the primary extension mechanism for project-specific customisations.
+
+Naming conventions:
+
+| What                   | Method name                  | Return type              |
+| ---------------------- | ---------------------------- | ------------------------ |
+| URL for a GET/POST     | `getXxxUrl(relevantArgs)`    | `string`                 |
+| Query params for a GET | `getXxxParams(relevantArgs)` | `URLSearchParams`        |
+| Body for a POST        | `getXxxBody(relevantArgs)`   | `Record<string, string>` |
+
+The main data-fetching method calls these extension points — it never hardcodes URLs or params inline:
+
+```typescript
+// ✅ Correct — URL and params extracted
+protected async fetchSegments(personalizationId: string): Promise<string[]> {
+  const response = await this.client.callGet<HclSegmentResponse>(
+    this.getSegmentsUrl(),
+    this.getSegmentsParams(personalizationId),
+    { allowUndefined: true },
+  );
+  // ...
+}
+
+protected getSegmentsUrl(): string {
+  return `${this.client.transactionBaseUrl}/segment`;
+}
+
+protected getSegmentsParams(personalizationId: string): URLSearchParams {
+  const params = new URLSearchParams();
+  params.set('q', 'byPersonalizationId');
+  params.set('qPersonalizationId', personalizationId);
+  return params;
+}
+
+// ❌ Wrong — hardcoded inline, impossible to override
+protected async fetchSegments(personalizationId: string): Promise<string[]> {
+  const params = new URLSearchParams();
+  params.set('q', 'byPersonalizationId');
+  const response = await this.client.callGet(
+    `${this.client.transactionBaseUrl}/segment`, params
+  );
+}
+```
+
+Real examples in this codebase:
+
+- `HclInventoryCapability` → `getBySKUUrl`, `getBySKUPayload`
+- `HclProductRecommendationsCapability` → `getEspotUrl`, `getEspotParams`
+- `HclAnalyticsCapability` → `getEventUrl`, `getEventBody`
+- `HclProductAssociationsCapability` → `getProductsUrl`, `getProductsParams`
+- `HclPersonalizationProfileCapability` → `getSegmentsUrl`, `getSegmentsParams`
+
+---
+
+## Factory pattern
+
+Factories parse raw HCL API responses into typed domain models.
+
+### Core factory interface (in `@reactionary/core`)
+
+```typescript
+// packages/core/src/factories/foo.factory.ts
+export type AnyFooSchema = z.ZodType<z.output<typeof FooSchema>>;
+
+export interface FooFactory<TFooSchema extends AnyFooSchema = AnyFooSchema> {
+  fooSchema: TFooSchema;
+  parseFoo(context: RequestContext, data: unknown): z.output<TFooSchema>;
+}
+
+export type FooFactoryOutput<TFactory extends FooFactory> = ReturnType<TFactory['parseFoo']>;
+
+export type FooFactoryWithOutput<TFactory extends FooFactory> = Omit<TFactory, 'parseFoo'> & {
+  parseFoo(context: RequestContext, data: unknown): FooFactoryOutput<TFactory>;
+};
+```
+
+Export from `packages/core/src/factories/index.ts`.
+
+### HCL-specific factory implementation
+
+```typescript
+// packages/hcl/src/factories/foo/foo.factory.ts
+export class HclFooFactory<TFooSchema extends AnyFooSchema = typeof FooSchema> implements FooFactory<TFooSchema> {
+  constructor(public readonly fooSchema: TFooSchema) {}
+
+  parseFoo(_context: RequestContext, data: HclFooData): z.output<TFooSchema> {
+    return this.fooSchema.parse({
+      // map HCL fields to domain model
+    });
+  }
+}
+```
+
+Export from `packages/hcl/src/factories/index.ts`.
+
+### Rules
+
+- Factories **always** receive the schema via constructor — never hardcode the schema class inside the factory
+- All response parsing lives in factories — capability methods must not call `.parse()` directly on domain schemas
+- Factory output is validated through the injected schema, so subclasses can extend the schema type
+
+---
+
+## Wiring capabilities in `initialize.ts`
+
+Use `resolveCapabilityWithFactory` for every capability that has a factory:
+
+```typescript
+if (caps.foo?.enabled) {
+  client.foo = resolveCapabilityWithFactory(
+    capabilities.foo as HclFooCapabilityConfig | undefined,
+    {
+      factory: new HclFooFactory(FooSchema),
+      capability: (args) => new HclFooCapability(args.cache, args.context, args.config, args.hclClient, args.factory),
+    },
+    buildCapabilityArgs,
+  );
+}
+```
+
+`resolveCapabilityWithFactory` lets callers override either the factory or the whole capability class by passing `{ factory, capability }` in the capabilities config object.
+
+For capabilities without factories (e.g. analytics), construct directly:
+
+```typescript
+if (caps.analytics?.enabled) {
+  client.analytics = new HclAnalyticsCapability(cache, context, config, hclClient);
+}
+```
+
+### `HclXxxCapabilityConfig` types
+
+Each capability gets a config type in `packages/hcl/src/schema/capabilities.schema.ts`:
+
+```typescript
+export type HclFooCapabilityConfig = HclCapabilityConfig<FooFactoryWithOutput<FooFactory>, FooCapability>;
+```
+
+Import `FooFactory` and `FooFactoryWithOutput` from `@reactionary/core`.
+
+---
+
+## Testing pattern
+
+**All tests are integration tests against a live HCL Commerce server.** There are no mocks.
+
+### Test file conventions
+
+- Location: `packages/hcl/src/test/<capability-name>.capability.spec.ts`
+- Top comment: `// Demo server: www-latestdevauth.demo.solteq.io, storeId=41`
+- `testData` const at the top with the specific product/category identifiers used
+
+### Test setup for factory-based capabilities
+
+Instantiate the capability directly (not via `createHclClient`) so the factory type is explicit:
+
+```typescript
+beforeEach(() => {
+  reqCtx = createInitialRequestContext();
+  const config = getHclTestConfiguration();
+  const client = new HclClient(config, reqCtx);
+  provider = new HclFooCapability(new NoOpCache(), reqCtx, config, client, new HclFooFactory(FooSchema));
+});
+```
+
+### Test setup for capabilities without factories
+
+```typescript
+beforeEach(() => {
+  reqCtx = createInitialRequestContext();
+  const config = getHclTestConfiguration();
+  const client = new HclClient(config, reqCtx);
+  provider = new HclAnalyticsCapability(new NoOpCache(), reqCtx, config, client);
+});
+```
+
+### Assertions
+
+- Use `assert(result.success, ...)` before accessing `result.value` — this narrows the type and gives a clear failure message:
+  ```typescript
+  assert(result.success, `Expected success, got: ${JSON.stringify(result)}`);
+  ```
+- For fire-and-forget results (analytics), accept both `accepted` and `rejected` — the live demo may not have the event endpoint configured:
+  ```typescript
+  expect(['accepted', 'rejected']).toContain(result.outcomes[0].outcome);
+  ```
+- For list results that may be empty on the demo server (espots, segments), assert shape not count:
+  ```typescript
+  expect(Array.isArray(result.value)).toBe(true);
+  expect(result.value.length).toBeLessThanOrEqual(query.numberOfRecommendations);
+  ```
+- Test environment credentials come from `.env` (gitignored). The template is `.env-template`.
+
+---
+
+## Common HCL Commerce quirks
+
+- **Product attributes** use a `string | string[]` zip pattern — multiple values in the same entry are stored as parallel arrays. See `flattenAttributeValues` in `product.factory.ts`.
+- **Slug resolution** uses `GET /search/resources/api/v2/urls?identifier=<slug>`. The slug resolves to `tokenValue` (a numeric uniqueID for categories) or `partNumber` for products — never use `tokenExternalValue`.
+- **Category breadcrumb** is encoded in `parentCatalogGroupID` as `/10501/10503` — split by `/`, the second-to-last segment is the direct parent.
+- **Profile names** control what fields the Query Service returns. Extra fields (e.g. `merchandisingAssociations`, `attachments`) are server-config-dependent and absent on the demo server even with the same profile name.
+- **`catalogBaseUrl`** defaults to `{searchApiUrl}/search/resources` (separate from `apiUrl` for deployments where search runs on a different host).
+- **`allowUndefined: true`** in `callGet` opts into returning `undefined` instead of throwing on 404 — use it for endpoints that may legitimately return nothing (espots, segments).

--- a/packages/core/src/factories/index.ts
+++ b/packages/core/src/factories/index.ts
@@ -15,6 +15,7 @@ export * from './price.factory.js';
 export * from './product.factory.js';
 export * from './product-associations.factory.js';
 export * from './product-list.factory.js';
+export * from './product-recommendations.factory.js';
 export * from './product-reviews.factory.js';
 export * from './product-search.factory.js';
 export * from './profile.factory.js';

--- a/packages/core/src/factories/product-recommendations.factory.ts
+++ b/packages/core/src/factories/product-recommendations.factory.ts
@@ -1,0 +1,31 @@
+import type * as z from 'zod';
+import type { ProductRecommendationSchema } from '../schemas/models/product-recommendations.model.js';
+import type { RequestContext } from '../schemas/session.schema.js';
+
+export type AnyProductRecommendationSchema = z.ZodType<
+  z.output<typeof ProductRecommendationSchema>
+>;
+
+export interface ProductRecommendationsFactory<
+  TProductRecommendationSchema extends
+    AnyProductRecommendationSchema = AnyProductRecommendationSchema,
+> {
+  productRecommendationSchema: TProductRecommendationSchema;
+  parseRecommendation(
+    context: RequestContext,
+    data: unknown,
+  ): z.output<TProductRecommendationSchema>;
+}
+
+export type ProductRecommendationsFactoryOutput<
+  TFactory extends ProductRecommendationsFactory,
+> = ReturnType<TFactory['parseRecommendation']>;
+
+export type ProductRecommendationsFactoryWithOutput<
+  TFactory extends ProductRecommendationsFactory,
+> = Omit<TFactory, 'parseRecommendation'> & {
+  parseRecommendation(
+    context: RequestContext,
+    data: unknown,
+  ): ProductRecommendationsFactoryOutput<TFactory>;
+};

--- a/packages/hcl/src/capabilities/analytics.capability.ts
+++ b/packages/hcl/src/capabilities/analytics.capability.ts
@@ -1,0 +1,121 @@
+import {
+  AnalyticsCapability,
+  AnalyticsMutationSchema,
+  AnalyticsResultSchema,
+  type AnalyticsMutation,
+  type AnalyticsMutationProductAddToCartEvent,
+  type AnalyticsMutationProductDetailsViewEvent,
+  type AnalyticsMutationProductSummaryClickEvent,
+  type AnalyticsMutationProductSummaryViewEvent,
+  type AnalyticsMutationPurchaseEvent,
+  type AnalyticsResult,
+  type Cache,
+  type RequestContext,
+  Reactionary,
+} from '@reactionary/core';
+import type { HclConfiguration } from '../schema/configuration.schema.js';
+import type { HclClient } from '../core/client.js';
+import { SESSION_KEY_PERSONALIZATION_ID } from '../core/session-keys.js';
+
+export class HclAnalyticsCapability extends AnalyticsCapability {
+  constructor(
+    cache: Cache,
+    context: RequestContext,
+    protected readonly config: HclConfiguration,
+    protected readonly client: HclClient,
+  ) {
+    super(cache, context);
+  }
+
+  @Reactionary({
+    inputSchema: AnalyticsMutationSchema,
+    outputSchema: AnalyticsResultSchema,
+  })
+  public override async track(
+    event: AnalyticsMutation,
+  ): Promise<AnalyticsResult> {
+    return super.track(event);
+  }
+
+  protected override async processProductSummaryView(
+    event: AnalyticsMutationProductSummaryViewEvent,
+  ): Promise<AnalyticsResult> {
+    try {
+      for (const product of event.products) {
+        await this.fireEvent({ productId: product.key });
+      }
+      return this.accepted();
+    } catch {
+      return this.rejected();
+    }
+  }
+
+  protected override async processProductSummaryClick(
+    event: AnalyticsMutationProductSummaryClickEvent,
+  ): Promise<AnalyticsResult> {
+    try {
+      await this.fireEvent({ productId: event.product.key });
+      return this.accepted();
+    } catch {
+      return this.rejected();
+    }
+  }
+
+  protected override async processProductDetailsView(
+    event: AnalyticsMutationProductDetailsViewEvent,
+  ): Promise<AnalyticsResult> {
+    try {
+      await this.fireEvent({ productId: event.product.key });
+      return this.accepted();
+    } catch {
+      return this.rejected();
+    }
+  }
+
+  protected override async processProductAddToCart(
+    event: AnalyticsMutationProductAddToCartEvent,
+  ): Promise<AnalyticsResult> {
+    try {
+      await this.fireEvent({ productId: event.product.key });
+      return this.accepted();
+    } catch {
+      return this.rejected();
+    }
+  }
+
+  protected override async processPurchase(
+    event: AnalyticsMutationPurchaseEvent,
+  ): Promise<AnalyticsResult> {
+    try {
+      for (const item of event.order.items) {
+        await this.fireEvent({ productId: item.variant.sku });
+      }
+      return this.accepted();
+    } catch {
+      return this.rejected();
+    }
+  }
+
+  protected async fireEvent(extra: Record<string, string>): Promise<void> {
+    await this.client.callPost<unknown>(
+      this.getEventUrl(),
+      this.getEventBody(extra),
+    );
+  }
+
+  protected getEventUrl(): string {
+    return `${this.client.transactionBaseUrl}/event`;
+  }
+
+  protected getEventBody(extra: Record<string, string>): Record<string, string> {
+    const personalizationID = this.context.session[
+      SESSION_KEY_PERSONALIZATION_ID
+    ] as string | undefined;
+
+    const body: Record<string, string> = { ...extra };
+    if (personalizationID) {
+      body['personalizationID'] = personalizationID;
+    }
+    return body;
+  }
+}

--- a/packages/hcl/src/capabilities/personalization-profile.capability.ts
+++ b/packages/hcl/src/capabilities/personalization-profile.capability.ts
@@ -1,0 +1,105 @@
+import {
+  PersonalizationProfileCapability,
+  PersonalizationProfileQueryGetProfileSchema,
+  PersonalizationProfileSchema,
+  Reactionary,
+  success,
+  type Cache,
+  type NotFoundError,
+  type PersonalizationProfileFactory,
+  type PersonalizationProfileFactoryOutput,
+  type PersonalizationProfileFactoryWithOutput,
+  type PersonalizationProfileQueryGetProfile,
+  type RequestContext,
+  type Result,
+} from '@reactionary/core';
+import type { HclConfiguration } from '../schema/configuration.schema.js';
+import type { HclClient } from '../core/client.js';
+import type { HclSegmentResponse } from '../schema/hcl.schema.js';
+import type { HclPersonalizationProfileFactory } from '../factories/personalization-profile/personalization-profile.factory.js';
+import { SESSION_KEY_PERSONALIZATION_ID } from '../core/session-keys.js';
+
+export class HclPersonalizationProfileCapability<
+  TFactory extends
+    PersonalizationProfileFactory = HclPersonalizationProfileFactory,
+> extends PersonalizationProfileCapability<
+  PersonalizationProfileFactoryOutput<TFactory>
+> {
+  constructor(
+    cache: Cache,
+    context: RequestContext,
+    protected readonly config: HclConfiguration,
+    protected readonly client: HclClient,
+    protected readonly factory: PersonalizationProfileFactoryWithOutput<TFactory>,
+  ) {
+    super(cache, context);
+  }
+
+  @Reactionary({
+    inputSchema: PersonalizationProfileQueryGetProfileSchema,
+    outputSchema: PersonalizationProfileSchema,
+  })
+  public override async getPersonalizationProfile(
+    _payload: PersonalizationProfileQueryGetProfile,
+  ): Promise<
+    Result<PersonalizationProfileFactoryOutput<TFactory>, NotFoundError>
+  > {
+    const personalizationId = this.context.session[
+      SESSION_KEY_PERSONALIZATION_ID
+    ] as string | undefined;
+
+    if (!personalizationId) {
+      return success(
+        this.factory.parsePersonalizationProfile(this.context, {
+          personalizationId: 'anonymous',
+          segments: [],
+        }),
+      );
+    }
+
+    const segments = await this.fetchSegments(personalizationId);
+
+    return success(
+      this.factory.parsePersonalizationProfile(this.context, {
+        personalizationId,
+        segments,
+      }),
+    );
+  }
+
+  /**
+   * Calls the WCS segment API to retrieve the customer segments for the given
+   * personalization ID. Returns an empty array when the API call fails or
+   * returns no segment data.
+   */
+  protected async fetchSegments(personalizationId: string): Promise<string[]> {
+    try {
+      const response = await this.client.callGet<HclSegmentResponse>(
+        this.getSegmentsUrl(),
+        this.getSegmentsParams(personalizationId),
+        { allowUndefined: true },
+      );
+
+      if (!response?.MemberGroup) {
+        return [];
+      }
+
+      return response.MemberGroup.map((g) => g.displayName?.value).filter(
+        (name): name is string => name !== undefined && name.length > 0,
+      );
+    } catch {
+      return [];
+    }
+  }
+
+  protected getSegmentsUrl(): string {
+    return `${this.client.transactionBaseUrl}/segment`;
+  }
+
+  protected getSegmentsParams(personalizationId: string): URLSearchParams {
+    const params = new URLSearchParams();
+    params.set('q', 'byPersonalizationId');
+    params.set('qPersonalizationId', personalizationId);
+    return params;
+  }
+}

--- a/packages/hcl/src/capabilities/product-associations.capability.ts
+++ b/packages/hcl/src/capabilities/product-associations.capability.ts
@@ -1,0 +1,141 @@
+import {
+  ProductAssociationsCapability,
+  ProductAssociationSchema,
+  ProductAssociationsGetAccessoriesQuerySchema,
+  ProductAssociationsGetSparepartsQuerySchema,
+  ProductAssociationsGetReplacementsQuerySchema,
+  Reactionary,
+  success,
+  type Cache,
+  type ProductAssociationsFactory,
+  type ProductAssociationsFactoryOutput,
+  type ProductAssociationsFactoryWithOutput,
+  type ProductAssociationsGetAccessoriesQuery,
+  type ProductAssociationsGetReplacementsQuery,
+  type ProductAssociationsGetSparepartsQuery,
+  type RequestContext,
+  type Result,
+} from '@reactionary/core';
+import type { HclConfiguration } from '../schema/configuration.schema.js';
+import type { HclClient } from '../core/client.js';
+import type {
+  HclAssociation,
+  HclProductQueryResponse,
+} from '../schema/hcl.schema.js';
+import type { HclProductAssociationsFactory } from '../factories/product-associations/product-associations.factory.js';
+import * as z from 'zod';
+
+export class HclProductAssociationsCapability<
+  TFactory extends ProductAssociationsFactory = HclProductAssociationsFactory,
+> extends ProductAssociationsCapability<
+  ProductAssociationsFactoryOutput<TFactory>
+> {
+  constructor(
+    cache: Cache,
+    context: RequestContext,
+    protected readonly config: HclConfiguration,
+    protected readonly client: HclClient,
+    protected readonly factory: ProductAssociationsFactoryWithOutput<TFactory>,
+  ) {
+    super(cache, context);
+  }
+
+  @Reactionary({
+    inputSchema: ProductAssociationsGetAccessoriesQuerySchema,
+    outputSchema: z.array(ProductAssociationSchema),
+    cache: true,
+    cacheTimeToLiveInSeconds: 300,
+    currencyDependentCaching: false,
+  })
+  public override async getAccessories(
+    query: ProductAssociationsGetAccessoriesQuery,
+  ): Promise<Result<ProductAssociationsFactoryOutput<TFactory>[]>> {
+    const associations = await this.fetchAssociations(
+      query.forProduct.key,
+      this.config.associationTypes.accessories,
+      query.numberOfAccessories,
+    );
+    return success(
+      associations.map((a) => this.factory.parseAssociation(this.context, a)),
+    );
+  }
+
+  @Reactionary({
+    inputSchema: ProductAssociationsGetSparepartsQuerySchema,
+    outputSchema: z.array(ProductAssociationSchema),
+    cache: true,
+    cacheTimeToLiveInSeconds: 300,
+    currencyDependentCaching: false,
+  })
+  public override async getSpareparts(
+    query: ProductAssociationsGetSparepartsQuery,
+  ): Promise<Result<ProductAssociationsFactoryOutput<TFactory>[]>> {
+    const associations = await this.fetchAssociations(
+      query.forProduct.key,
+      this.config.associationTypes.spareparts,
+      query.numberOfSpareparts,
+    );
+    return success(
+      associations.map((a) => this.factory.parseAssociation(this.context, a)),
+    );
+  }
+
+  @Reactionary({
+    inputSchema: ProductAssociationsGetReplacementsQuerySchema,
+    outputSchema: z.array(ProductAssociationSchema),
+    cache: true,
+    cacheTimeToLiveInSeconds: 300,
+    currencyDependentCaching: false,
+  })
+  public override async getReplacements(
+    query: ProductAssociationsGetReplacementsQuery,
+  ): Promise<Result<ProductAssociationsFactoryOutput<TFactory>[]>> {
+    const associations = await this.fetchAssociations(
+      query.forProduct.key,
+      this.config.associationTypes.replacements,
+      query.numberOfReplacements,
+    );
+    return success(
+      associations.map((a) => this.factory.parseAssociation(this.context, a)),
+    );
+  }
+
+  /**
+   * Fetches the product detail for the given part number and returns the
+   * `merchandisingAssociations` filtered to the requested association types,
+   * capped at `maxCount`.
+   */
+  protected async fetchAssociations(
+    partNumber: string,
+    types: string[],
+    maxCount: number,
+  ): Promise<HclAssociation[]> {
+    const response = await this.client.callGet<HclProductQueryResponse>(
+      this.getProductsUrl(),
+      this.getProductsParams(partNumber),
+    );
+
+    const product = (response.contents ?? response.catalogEntryView ?? [])[0];
+    if (!product?.merchandisingAssociations) {
+      return [];
+    }
+
+    return product.merchandisingAssociations
+      .filter(
+        (a) => a.associationCodeType && types.includes(a.associationCodeType),
+      )
+      .slice(0, maxCount);
+  }
+
+  protected getProductsUrl(): string {
+    return `${this.client.catalogBaseUrl}/api/v2/products`;
+  }
+
+  protected getProductsParams(partNumber: string): URLSearchParams {
+    const params = new URLSearchParams();
+    params.set('storeId', this.config.storeId);
+    params.append('partNumber', partNumber);
+    params.set('profileName', this.config.profiles.product);
+    return params;
+  }
+}

--- a/packages/hcl/src/capabilities/product-recommendations.capability.ts
+++ b/packages/hcl/src/capabilities/product-recommendations.capability.ts
@@ -1,0 +1,193 @@
+import {
+  ProductRecommendationsCapability,
+  ProductRecommendationsQuerySchema,
+  ProductRecommendationsByCollectionQuerySchema,
+  Reactionary,
+  type Cache,
+  type ProductRecommendation,
+  type ProductRecommendationAlgorithmAlsoViewedProductsQuery,
+  type ProductRecommendationAlgorithmFrequentlyBoughtTogetherQuery,
+  type ProductRecommendationAlgorithmPopuplarProductsQuery,
+  type ProductRecommendationAlgorithmRelatedProductsQuery,
+  type ProductRecommendationAlgorithmSimilarProductsQuery,
+  type ProductRecommendationAlgorithmTopPicksProductsQuery,
+  type ProductRecommendationAlgorithmTrendingInCategoryQuery,
+  type ProductRecommendationsByCollectionQuery,
+  type ProductRecommendationsFactory,
+  type ProductRecommendationsFactoryWithOutput,
+  type RequestContext,
+  type Result,
+  success,
+} from '@reactionary/core';
+import type { HclConfiguration } from '../schema/configuration.schema.js';
+import type { HclClient } from '../core/client.js';
+import type { HclEspotResponse } from '../schema/hcl.schema.js';
+import type { HclProductRecommendationsFactory } from '../factories/product-recommendations/product-recommendations.factory.js';
+
+export class HclProductRecommendationsCapability<
+  TFactory extends
+    ProductRecommendationsFactory = HclProductRecommendationsFactory,
+> extends ProductRecommendationsCapability {
+  constructor(
+    cache: Cache,
+    context: RequestContext,
+    protected readonly config: HclConfiguration,
+    protected readonly client: HclClient,
+    protected readonly factory: ProductRecommendationsFactoryWithOutput<TFactory>,
+  ) {
+    super(cache, context);
+  }
+
+  @Reactionary({
+    inputSchema: ProductRecommendationsQuerySchema,
+  })
+  public override getRecommendations(
+    ...args: Parameters<ProductRecommendationsCapability['getRecommendations']>
+  ) {
+    return super.getRecommendations(...args);
+  }
+
+  @Reactionary({
+    inputSchema: ProductRecommendationsByCollectionQuerySchema,
+  })
+  public override async getCollection(
+    query: ProductRecommendationsByCollectionQuery,
+  ): Promise<Result<ProductRecommendation[]>> {
+    const params: Record<string, string | undefined> = {
+      productId: query.sourceProduct?.[0]?.key,
+      categoryId: query.sourceCategory?.key,
+      count: String(query.numberOfRecommendations),
+    };
+    const recommendations = await this.fetchEspot(
+      query.collectionName,
+      query.collectionName,
+      params,
+    );
+    return success(recommendations.slice(0, query.numberOfRecommendations));
+  }
+
+  protected override async getFrequentlyBoughtTogetherRecommendations(
+    query: ProductRecommendationAlgorithmFrequentlyBoughtTogetherQuery,
+  ): Promise<ProductRecommendation[]> {
+    return this.fetchEspot(
+      this.config.espotNames.frequentlyBoughtTogether,
+      'frequentlyBoughtTogether',
+      {
+        productId: query.sourceProduct.key,
+        count: String(query.numberOfRecommendations),
+      },
+    );
+  }
+
+  protected override async getSimilarProductsRecommendations(
+    query: ProductRecommendationAlgorithmSimilarProductsQuery,
+  ): Promise<ProductRecommendation[]> {
+    return this.fetchEspot(this.config.espotNames.similar, 'similar', {
+      productId: query.sourceProduct.key,
+      count: String(query.numberOfRecommendations),
+    });
+  }
+
+  protected override async getRelatedProductsRecommendations(
+    query: ProductRecommendationAlgorithmRelatedProductsQuery,
+  ): Promise<ProductRecommendation[]> {
+    return this.fetchEspot(this.config.espotNames.related, 'related', {
+      productId: query.sourceProduct.key,
+      count: String(query.numberOfRecommendations),
+    });
+  }
+
+  protected override async getTrendingInCategoryRecommendations(
+    query: ProductRecommendationAlgorithmTrendingInCategoryQuery,
+  ): Promise<ProductRecommendation[]> {
+    return this.fetchEspot(
+      this.config.espotNames.trendingInCategory,
+      'trendingInCategory',
+      {
+        categoryId: query.sourceCategory.key,
+        count: String(query.numberOfRecommendations),
+      },
+    );
+  }
+
+  protected override async getPopularProductsRecommendations(
+    query: ProductRecommendationAlgorithmPopuplarProductsQuery,
+  ): Promise<ProductRecommendation[]> {
+    return this.fetchEspot(this.config.espotNames.popular, 'popular', {
+      count: String(query.numberOfRecommendations),
+    });
+  }
+
+  protected override async getTopPicksProductsRecommendations(
+    query: ProductRecommendationAlgorithmTopPicksProductsQuery,
+  ): Promise<ProductRecommendation[]> {
+    return this.fetchEspot(this.config.espotNames.topPicks, 'topPicks', {
+      count: String(query.numberOfRecommendations),
+    });
+  }
+
+  protected override async getAlsoViewedProductsRecommendations(
+    query: ProductRecommendationAlgorithmAlsoViewedProductsQuery,
+  ): Promise<ProductRecommendation[]> {
+    return this.fetchEspot(this.config.espotNames.alsoViewed, 'alsoViewed', {
+      productId: query.sourceProduct.key,
+      count: String(query.numberOfRecommendations),
+    });
+  }
+
+  /**
+   * Calls an HCL marketing spot (espot) by name and maps its catalog entry
+   * activity data to `ProductRecommendation[]` using the factory.
+   *
+   * Returns an empty array when the espot is not found (404) or returns no
+   * catalog entry data — allowing teams to configure only the espots they need.
+   */
+  protected async fetchEspot(
+    name: string,
+    algorithm: string,
+    params: Record<string, string | undefined> = {},
+  ): Promise<ProductRecommendation[]> {
+    const response = await this.client.callGet<HclEspotResponse>(
+      this.getEspotUrl(name),
+      this.getEspotParams(params),
+      { allowUndefined: true },
+    );
+
+    if (!response) {
+      return [];
+    }
+
+    const activities =
+      response.MarketingSpotData?.[0]?.baseMarketingSpotActivityData ?? [];
+
+    return activities
+      .filter(
+        (a) =>
+          a.baseMarketingSpotDataType === 'CatalogEntry' ||
+          a.baseMarketingSpotDataType === 'CatalogEntryId',
+      )
+      .map((a) =>
+        this.factory.parseRecommendation(this.context, {
+          activityData: a,
+          algorithm,
+        }),
+      )
+      .filter((r) => r.product.key !== '');
+  }
+
+  protected getEspotUrl(name: string): string {
+    return `${this.client.transactionBaseUrl}/espot/${encodeURIComponent(name)}`;
+  }
+
+  protected getEspotParams(
+    params: Record<string, string | undefined>,
+  ): URLSearchParams {
+    const searchParams = new URLSearchParams();
+    const count = params['count'];
+    if (count) searchParams.set('DM_DisplayProducts', count);
+    if (params['productId']) searchParams.set('productId', params['productId']);
+    if (params['categoryId'])
+      searchParams.set('categoryId', params['categoryId']);
+    return searchParams;
+  }
+}

--- a/packages/hcl/src/core/initialize.ts
+++ b/packages/hcl/src/core/initialize.ts
@@ -4,6 +4,9 @@ import {
   IdentitySchema,
   OrderSchema,
   OrderSearchResultSchema,
+  PersonalizationProfileSchema,
+  ProductAssociationSchema,
+  ProductRecommendationSchema,
   ProductSchema,
   ProfileSchema,
 } from '@reactionary/core';
@@ -22,6 +25,10 @@ import {
   type HclProfileCapabilityConfig,
   type HclOrderCapabilityConfig,
   type HclOrderSearchCapabilityConfig,
+  type HclAnalyticsCapabilityConfig,
+  type HclProductAssociationsCapabilityConfig,
+  type HclProductRecommendationsCapabilityConfig,
+  type HclPersonalizationProfileCapabilityConfig,
 } from '../schema/capabilities.schema.js';
 import {
   HclConfigurationSchema,
@@ -40,8 +47,11 @@ import {
   HclInventoryFactory,
   HclOrderFactory,
   HclOrderSearchFactory,
+  HclPersonalizationProfileFactory,
   HclPriceFactory,
+  HclProductAssociationsFactory,
   HclProductFactory,
+  HclProductRecommendationsFactory,
   HclProductSearchFactory,
   HclProfileFactory,
 } from '../factories/index.js';
@@ -56,6 +66,10 @@ import { HclIdentityCapability } from '../capabilities/identity.capability.js';
 import { HclProfileCapability } from '../capabilities/profile.capability.js';
 import { HclOrderCapability } from '../capabilities/order.capability.js';
 import { HclOrderSearchCapability } from '../capabilities/order-search.capability.js';
+import { HclAnalyticsCapability } from '../capabilities/analytics.capability.js';
+import { HclProductAssociationsCapability } from '../capabilities/product-associations.capability.js';
+import { HclProductRecommendationsCapability } from '../capabilities/product-recommendations.capability.js';
+import { HclPersonalizationProfileCapability } from '../capabilities/personalization-profile.capability.js';
 import {
   CartIdentifierSchema,
   CartPaginatedSearchResultSchema,
@@ -290,6 +304,88 @@ export function withHclCapabilities<T extends HclCapabilities>(
           factory: new HclOrderSearchFactory(OrderSearchResultSchema),
           capability: (args) =>
             new HclOrderSearchCapability(
+              args.cache,
+              args.context,
+              args.config,
+              args.hclClient,
+              args.factory,
+            ),
+        },
+        buildCapabilityArgs,
+      );
+    }
+
+    if (caps.analytics?.enabled) {
+      const analyticsCap = capabilities.analytics as
+        | HclAnalyticsCapabilityConfig
+        | undefined;
+      if (analyticsCap?.capability) {
+        client.analytics = analyticsCap.capability(
+          buildCapabilityArgs(undefined as never) as never,
+        );
+      } else {
+        client.analytics = new HclAnalyticsCapability(
+          cache,
+          context,
+          config,
+          hclClient,
+        );
+      }
+    }
+
+    if (caps.productAssociations?.enabled) {
+      client.productAssociations = resolveCapabilityWithFactory(
+        capabilities.productAssociations as
+          | HclProductAssociationsCapabilityConfig
+          | undefined,
+        {
+          factory: new HclProductAssociationsFactory(ProductAssociationSchema),
+          capability: (args) =>
+            new HclProductAssociationsCapability(
+              args.cache,
+              args.context,
+              args.config,
+              args.hclClient,
+              args.factory,
+            ),
+        },
+        buildCapabilityArgs,
+      );
+    }
+
+    if (caps.productRecommendations?.enabled) {
+      client.productRecommendations = resolveCapabilityWithFactory(
+        capabilities.productRecommendations as
+          | HclProductRecommendationsCapabilityConfig
+          | undefined,
+        {
+          factory: new HclProductRecommendationsFactory(
+            ProductRecommendationSchema,
+          ),
+          capability: (args) =>
+            new HclProductRecommendationsCapability(
+              args.cache,
+              args.context,
+              args.config,
+              args.hclClient,
+              args.factory,
+            ),
+        },
+        buildCapabilityArgs,
+      );
+    }
+
+    if (caps.personalizationProfile?.enabled) {
+      client.personalizationProfile = resolveCapabilityWithFactory(
+        capabilities.personalizationProfile as
+          | HclPersonalizationProfileCapabilityConfig
+          | undefined,
+        {
+          factory: new HclPersonalizationProfileFactory(
+            PersonalizationProfileSchema,
+          ),
+          capability: (args) =>
+            new HclPersonalizationProfileCapability(
               args.cache,
               args.context,
               args.config,

--- a/packages/hcl/src/factories/index.ts
+++ b/packages/hcl/src/factories/index.ts
@@ -9,3 +9,6 @@ export * from './identity/identity.factory.js';
 export * from './profile/profile.factory.js';
 export * from './order/order.factory.js';
 export * from './order-search/order-search.factory.js';
+export * from './product-associations/product-associations.factory.js';
+export * from './product-recommendations/product-recommendations.factory.js';
+export * from './personalization-profile/personalization-profile.factory.js';

--- a/packages/hcl/src/factories/personalization-profile/personalization-profile.factory.ts
+++ b/packages/hcl/src/factories/personalization-profile/personalization-profile.factory.ts
@@ -1,0 +1,35 @@
+import type {
+  AnyPersonalizationProfileSchema,
+  PersonalizationProfileFactory,
+  PersonalizationProfileSchema,
+  RequestContext,
+} from '@reactionary/core';
+import type * as z from 'zod';
+
+export interface HclPersonalizationProfileData {
+  personalizationId: string;
+  segments: string[];
+}
+
+export class HclPersonalizationProfileFactory<
+  TPersonalizationProfileSchema extends
+    AnyPersonalizationProfileSchema = typeof PersonalizationProfileSchema,
+> implements PersonalizationProfileFactory<TPersonalizationProfileSchema>
+{
+  public readonly personalizationProfileSchema: TPersonalizationProfileSchema;
+
+  constructor(personalizationProfileSchema: TPersonalizationProfileSchema) {
+    this.personalizationProfileSchema = personalizationProfileSchema;
+  }
+
+  public parsePersonalizationProfile(
+    _context: RequestContext,
+    data: HclPersonalizationProfileData,
+  ): z.output<TPersonalizationProfileSchema> {
+    return this.personalizationProfileSchema.parse({
+      identifier: { key: data.personalizationId },
+      segments: data.segments,
+      blurb: '',
+    });
+  }
+}

--- a/packages/hcl/src/factories/product-associations/product-associations.factory.ts
+++ b/packages/hcl/src/factories/product-associations/product-associations.factory.ts
@@ -1,0 +1,31 @@
+import type {
+  AnyProductAssociationSchema,
+  ProductAssociationSchema,
+  ProductAssociationsFactory,
+  RequestContext,
+} from '@reactionary/core';
+import type * as z from 'zod';
+import type { HclAssociation } from '../../schema/hcl.schema.js';
+
+export class HclProductAssociationsFactory<
+  TProductAssociationSchema extends
+    AnyProductAssociationSchema = typeof ProductAssociationSchema,
+> implements ProductAssociationsFactory<TProductAssociationSchema>
+{
+  public readonly productAssociationSchema: TProductAssociationSchema;
+
+  constructor(productAssociationSchema: TProductAssociationSchema) {
+    this.productAssociationSchema = productAssociationSchema;
+  }
+
+  public parseAssociation(
+    _context: RequestContext,
+    data: HclAssociation,
+  ): z.output<TProductAssociationSchema> {
+    return this.productAssociationSchema.parse({
+      associationIdentifier: { key: data.partNumber },
+      associationReturnType: 'idOnly',
+      product: { key: data.partNumber },
+    });
+  }
+}

--- a/packages/hcl/src/factories/product-recommendations/product-recommendations.factory.ts
+++ b/packages/hcl/src/factories/product-recommendations/product-recommendations.factory.ts
@@ -1,0 +1,39 @@
+import type {
+  AnyProductRecommendationSchema,
+  ProductRecommendationSchema,
+  ProductRecommendationsFactory,
+  RequestContext,
+} from '@reactionary/core';
+import type * as z from 'zod';
+import type { HclEspotActivityData } from '../../schema/hcl.schema.js';
+
+export interface HclEspotRecommendationData {
+  activityData: HclEspotActivityData;
+  algorithm: string;
+}
+
+export class HclProductRecommendationsFactory<
+  TProductRecommendationSchema extends
+    AnyProductRecommendationSchema = typeof ProductRecommendationSchema,
+> implements ProductRecommendationsFactory<TProductRecommendationSchema>
+{
+  public readonly productRecommendationSchema: TProductRecommendationSchema;
+
+  constructor(productRecommendationSchema: TProductRecommendationSchema) {
+    this.productRecommendationSchema = productRecommendationSchema;
+  }
+
+  public parseRecommendation(
+    _context: RequestContext,
+    data: HclEspotRecommendationData,
+  ): z.output<TProductRecommendationSchema> {
+    // partNumber returned inline is preferred; fall back to contentId (internal uniqueID)
+    const key =
+      data.activityData.partNumber ?? data.activityData.contentId ?? '';
+    return this.productRecommendationSchema.parse({
+      recommendationIdentifier: { key, algorithm: data.algorithm },
+      recommendationReturnType: 'idOnly',
+      product: { key },
+    });
+  }
+}

--- a/packages/hcl/src/index.ts
+++ b/packages/hcl/src/index.ts
@@ -17,3 +17,7 @@ export * from './capabilities/identity.capability.js';
 export * from './capabilities/profile.capability.js';
 export * from './capabilities/order.capability.js';
 export * from './capabilities/order-search.capability.js';
+export * from './capabilities/analytics.capability.js';
+export * from './capabilities/product-associations.capability.js';
+export * from './capabilities/product-recommendations.capability.js';
+export * from './capabilities/personalization-profile.capability.js';

--- a/packages/hcl/src/schema/capabilities.schema.ts
+++ b/packages/hcl/src/schema/capabilities.schema.ts
@@ -1,6 +1,7 @@
 import type {
   Cache,
   RequestContext,
+  AnalyticsCapability,
   CartFactory,
   CartFactoryWithOutput,
   CartCapability,
@@ -22,12 +23,21 @@ import type {
   OrderSearchFactory,
   OrderSearchFactoryWithOutput,
   OrderSearchCapability,
+  PersonalizationProfileCapability,
+  PersonalizationProfileFactory,
+  PersonalizationProfileFactoryWithOutput,
   PriceFactory,
   PriceFactoryWithOutput,
   PriceCapability,
+  ProductAssociationsCapability,
+  ProductAssociationsFactory,
+  ProductAssociationsFactoryWithOutput,
   ProductFactory,
   ProductFactoryWithOutput,
   ProductCapability,
+  ProductRecommendationsCapability,
+  ProductRecommendationsFactory,
+  ProductRecommendationsFactoryWithOutput,
   ProductSearchFactory,
   ProductSearchFactoryWithOutput,
   ProductSearchCapability,
@@ -58,6 +68,10 @@ export const HclCapabilitiesSchema = CapabilitiesSchema.pick({
   profile: true,
   order: true,
   orderSearch: true,
+  analytics: true,
+  productAssociations: true,
+  productRecommendations: true,
+  personalizationProfile: true,
 })
   .extend({
     cart: OverridableCapabilitySchema.optional(),
@@ -71,6 +85,10 @@ export const HclCapabilitiesSchema = CapabilitiesSchema.pick({
     profile: OverridableCapabilitySchema.optional(),
     order: OverridableCapabilitySchema.optional(),
     orderSearch: OverridableCapabilitySchema.optional(),
+    analytics: OverridableCapabilitySchema.optional(),
+    productAssociations: OverridableCapabilitySchema.optional(),
+    productRecommendations: OverridableCapabilitySchema.optional(),
+    personalizationProfile: OverridableCapabilitySchema.optional(),
   })
   .partial();
 
@@ -147,4 +165,26 @@ export type HclOrderCapabilityConfig = HclCapabilityConfig<
 export type HclOrderSearchCapabilityConfig = HclCapabilityConfig<
   OrderSearchFactoryWithOutput<OrderSearchFactory>,
   OrderSearchCapability
+>;
+
+/** Analytics does not use a factory — the capability writes events directly. */
+export type HclAnalyticsCapabilityConfig = HclCapabilityConfig<
+  never,
+  AnalyticsCapability
+>;
+
+export type HclProductAssociationsCapabilityConfig = HclCapabilityConfig<
+  ProductAssociationsFactoryWithOutput<ProductAssociationsFactory>,
+  ProductAssociationsCapability
+>;
+
+/** Product recommendations uses a factory to parse espot activity data into recommendations. */
+export type HclProductRecommendationsCapabilityConfig = HclCapabilityConfig<
+  ProductRecommendationsFactoryWithOutput<ProductRecommendationsFactory>,
+  ProductRecommendationsCapability
+>;
+
+export type HclPersonalizationProfileCapabilityConfig = HclCapabilityConfig<
+  PersonalizationProfileFactoryWithOutput<PersonalizationProfileFactory>,
+  PersonalizationProfileCapability
 >;

--- a/packages/hcl/src/schema/configuration.schema.ts
+++ b/packages/hcl/src/schema/configuration.schema.ts
@@ -66,6 +66,46 @@ export const HclConfigurationSchema = z.looseObject({
     description:
       'Price rule ID for /display_price WCS calls. Optional — the server uses its default rule when absent.',
   }),
+  /**
+   * Maps Reactionary association types to the HCL `associationCodeType` values
+   * returned in `merchandisingAssociations` on product detail responses.
+   * Override to match custom HCL store configuration.
+   */
+  associationTypes: z
+    .looseObject({
+      accessories: z.array(z.string()).default(['ACCESSORY']),
+      spareparts: z.array(z.string()).default(['SPAREPART']),
+      replacements: z.array(z.string()).default(['REPLACEMENT']),
+    })
+    .default(() => ({
+      accessories: ['ACCESSORY'],
+      spareparts: ['SPAREPART'],
+      replacements: ['REPLACEMENT'],
+    })),
+  /**
+   * Names of HCL marketing spots used for product recommendation algorithms.
+   * Each algorithm calls the corresponding named espot via the WCS Transaction Service.
+   * These espots must be configured in HCL Commerce to return catalog entry data.
+   */
+  espotNames: z
+    .looseObject({
+      frequentlyBoughtTogether: z.string().default('Reactionary_FrequentlyBoughtTogether'),
+      similar: z.string().default('Reactionary_SimilarProducts'),
+      related: z.string().default('Reactionary_RelatedProducts'),
+      trendingInCategory: z.string().default('Reactionary_TrendingInCategory'),
+      popular: z.string().default('Reactionary_Popular'),
+      topPicks: z.string().default('Reactionary_TopPicks'),
+      alsoViewed: z.string().default('Reactionary_AlsoViewed'),
+    })
+    .default(() => ({
+      frequentlyBoughtTogether: 'Reactionary_FrequentlyBoughtTogether',
+      similar: 'Reactionary_SimilarProducts',
+      related: 'Reactionary_RelatedProducts',
+      trendingInCategory: 'Reactionary_TrendingInCategory',
+      popular: 'Reactionary_Popular',
+      topPicks: 'Reactionary_TopPicks',
+      alsoViewed: 'Reactionary_AlsoViewed',
+    })),
 });
 
 export type HclConfiguration = z.infer<typeof HclConfigurationSchema>;

--- a/packages/hcl/src/schema/hcl.schema.ts
+++ b/packages/hcl/src/schema/hcl.schema.ts
@@ -239,7 +239,7 @@ export interface HclProductResponse extends HclProductSearchItem {
   components?: HclProductResponse[];
   /** Quantity — only present on components array elements */
   quantity?: string;
-  merchandisingAssociations?: HclProductResponse[];
+  merchandisingAssociations?: HclAssociation[];
   attachments?: HclAttachment[];
   images?: HclImage[];
   /**
@@ -729,4 +729,74 @@ export interface HclWcsOrderHistoryResponse {
   recordSetCount?: string;
   recordSetStartNumber?: string;
   recordSetComplete?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Query Service — Merchandising Associations
+// ---------------------------------------------------------------------------
+
+/**
+ * A product item returned within a `merchandisingAssociations` array on a
+ * HCL detail-profile product response. Extends the search item shape with
+ * an `associationCodeType` that identifies the semantic relationship.
+ *
+ * Known values: 'ACCESSORY', 'SPAREPART', 'REPLACEMENT', 'CROSSSELL', 'UPSELL', 'UPGRADE'
+ */
+export interface HclAssociation extends HclProductSearchItem {
+  /** The association type code. e.g. 'ACCESSORY', 'SPAREPART', 'REPLACEMENT'. */
+  associationCodeType?: string;
+  /** Display sequence for ordering associations within a type. */
+  associationSequence?: string;
+}
+
+// ---------------------------------------------------------------------------
+// WCS Transaction Service — Marketing / ESpot
+// ---------------------------------------------------------------------------
+
+/**
+ * A single activity data entry within a marketing spot response.
+ * When `baseMarketingSpotDataType` is 'CatalogEntry' or 'CatalogEntryId',
+ * the entry represents a product recommendation from the spot.
+ */
+export interface HclEspotActivityData {
+  /** 'CatalogEntry' | 'CatalogEntryId' | 'CatalogGroupId' | 'MarketingContent' */
+  baseMarketingSpotDataType?: string;
+  /** Internal HCL product uniqueID (numeric string). Present for CatalogEntry/CatalogEntryId types. */
+  contentId?: string;
+  /** Part number of the product, if returned inline by the spot configuration. */
+  partNumber?: string;
+  /** Display name of the product or content entry. */
+  contentName?: string;
+}
+
+/** A single marketing spot entry in a WCS espot response. */
+export interface HclEspotMarketingSpot {
+  eSpotName?: string;
+  baseMarketingSpotActivityData?: HclEspotActivityData[];
+}
+
+/** Top-level response from GET /wcs/resources/store/{storeId}/espot/{name}. */
+export interface HclEspotResponse {
+  MarketingSpotData?: HclEspotMarketingSpot[];
+}
+
+// ---------------------------------------------------------------------------
+// WCS Transaction Service — Segment / Personalization
+// ---------------------------------------------------------------------------
+
+/** A single customer segment (member group) entry in a WCS segment response. */
+export interface HclSegmentMemberGroup {
+  id: string;
+  displayName?: { language: number; value: string };
+  description?: { language: number; value: string };
+  usage?: string[];
+}
+
+/** Top-level response from GET /wcs/resources/store/{storeId}/segment. */
+export interface HclSegmentResponse {
+  MemberGroup?: HclSegmentMemberGroup[];
+  recordSetTotal?: number;
+  recordSetCount?: number;
+  recordSetStartNumber?: number;
+  recordSetComplete?: boolean;
 }

--- a/packages/hcl/src/test/analytics.capability.spec.ts
+++ b/packages/hcl/src/test/analytics.capability.spec.ts
@@ -1,0 +1,123 @@
+import 'dotenv/config';
+import type {
+  AnalyticsMutationPurchaseEvent,
+  RequestContext,
+} from '@reactionary/core';
+import { NoOpCache, createInitialRequestContext } from '@reactionary/core';
+import { describe, expect, it, beforeEach } from 'vitest';
+import { HclAnalyticsCapability } from '../capabilities/analytics.capability.js';
+import { HclClient } from '../core/client.js';
+import { getHclTestConfiguration } from './test-utils.js';
+
+// Demo server: www-latestdevauth.demo.solteq.io, storeId=41
+const testData = {
+  product: { key: 'DR-CHRS-0001' },
+  variant: { sku: 'DR-CHRS-0001-0001' },
+};
+
+describe('HCL Analytics Capability', () => {
+  let provider: HclAnalyticsCapability;
+  let reqCtx: RequestContext;
+
+  beforeEach(() => {
+    reqCtx = createInitialRequestContext();
+    const config = getHclTestConfiguration();
+    const client = new HclClient(config, reqCtx);
+    provider = new HclAnalyticsCapability(
+      new NoOpCache(),
+      reqCtx,
+      config,
+      client,
+    );
+  });
+
+  it('should track a product-summary-view event', async () => {
+    const result = await provider.track({
+      event: 'product-summary-view',
+      products: [testData.product],
+    });
+
+    expect(result.outcomes).toHaveLength(1);
+    expect(['accepted', 'rejected']).toContain(result.outcomes[0].outcome);
+  });
+
+  it('should track a product-summary-click event', async () => {
+    const result = await provider.track({
+      event: 'product-summary-click',
+      product: testData.product,
+      position: 0,
+    });
+
+    expect(result.outcomes).toHaveLength(1);
+    expect(['accepted', 'rejected']).toContain(result.outcomes[0].outcome);
+  });
+
+  it('should track a product-details-view event', async () => {
+    const result = await provider.track({
+      event: 'product-details-view',
+      product: testData.product,
+    });
+
+    expect(result.outcomes).toHaveLength(1);
+    expect(['accepted', 'rejected']).toContain(result.outcomes[0].outcome);
+  });
+
+  it('should track a product-cart-add event', async () => {
+    const result = await provider.track({
+      event: 'product-cart-add',
+      product: testData.product,
+    });
+
+    expect(result.outcomes).toHaveLength(1);
+    expect(['accepted', 'rejected']).toContain(result.outcomes[0].outcome);
+  });
+
+  it('should track a purchase event', async () => {
+    const event = {
+      event: 'purchase',
+      order: {
+        identifier: { key: 'TEST-ORDER-001' },
+        userId: { userId: 'test-user-anonymous' },
+        items: [
+          {
+            identifier: { key: 'item-1' },
+            variant: testData.variant,
+            quantity: 1,
+            price: {
+              unitPrice: { value: 99.99, currency: 'USD' },
+              unitDiscount: { value: 0, currency: 'USD' },
+              totalPrice: { value: 99.99, currency: 'USD' },
+              totalDiscount: { value: 0, currency: 'USD' },
+            },
+            inventoryStatus: 'Allocated',
+          },
+        ],
+        price: {
+          totalTax: { value: 10, currency: 'USD' },
+          totalDiscount: { value: 0, currency: 'USD' },
+          totalSurcharge: { value: 0, currency: 'USD' },
+          totalShipping: { value: 5, currency: 'USD' },
+          totalProductPrice: { value: 99.99, currency: 'USD' },
+          grandTotal: { value: 114.99, currency: 'USD' },
+        },
+        orderStatus: 'AwaitingPayment',
+        inventoryStatus: 'Allocated',
+        paymentInstructions: [],
+      },
+    } satisfies AnalyticsMutationPurchaseEvent;
+
+    const result = await provider.track(event);
+
+    expect(result.outcomes).toHaveLength(1);
+    expect(['accepted', 'rejected']).toContain(result.outcomes[0].outcome);
+  });
+
+  it('should include provider name in outcomes', async () => {
+    const result = await provider.track({
+      event: 'product-summary-view',
+      products: [testData.product],
+    });
+
+    expect(result.outcomes[0].provider).toBeTruthy();
+  });
+});

--- a/packages/hcl/src/test/personalization-profile.capability.spec.ts
+++ b/packages/hcl/src/test/personalization-profile.capability.spec.ts
@@ -1,0 +1,67 @@
+import 'dotenv/config';
+import type { RequestContext } from '@reactionary/core';
+import {
+  NoOpCache,
+  PersonalizationProfileSchema,
+  createInitialRequestContext,
+} from '@reactionary/core';
+import { describe, expect, it, beforeEach, assert } from 'vitest';
+import { HclPersonalizationProfileCapability } from '../capabilities/personalization-profile.capability.js';
+import { HclPersonalizationProfileFactory } from '../factories/index.js';
+import { HclClient } from '../core/client.js';
+import { SESSION_KEY_PERSONALIZATION_ID } from '../core/session-keys.js';
+import { getHclTestConfiguration } from './test-utils.js';
+
+// Demo server: www-latestdevauth.demo.solteq.io, storeId=41
+describe('HCL Personalization Profile Capability', () => {
+  let provider: HclPersonalizationProfileCapability;
+  let reqCtx: RequestContext;
+
+  beforeEach(() => {
+    reqCtx = createInitialRequestContext();
+    const config = getHclTestConfiguration();
+    const client = new HclClient(config, reqCtx);
+    provider = new HclPersonalizationProfileCapability(
+      new NoOpCache(),
+      reqCtx,
+      config,
+      client,
+      new HclPersonalizationProfileFactory(PersonalizationProfileSchema),
+    );
+  });
+
+  it('should return an anonymous profile when no personalization ID is in session', async () => {
+    const result = await provider.getPersonalizationProfile({
+      identity: { type: 'Anonymous' },
+    });
+
+    assert(result.success, `Expected success, got: ${JSON.stringify(result)}`);
+    expect(result.value.identifier.key).toBe('anonymous');
+    expect(result.value.segments).toEqual([]);
+  });
+
+  it('should return a profile with the personalization ID from session', async () => {
+    // Use a synthetic personalization ID — segments may be empty if unknown to the server
+    reqCtx.session[SESSION_KEY_PERSONALIZATION_ID] = '1234567890';
+
+    const result = await provider.getPersonalizationProfile({
+      identity: { type: 'Anonymous' },
+    });
+
+    assert(result.success, `Expected success, got: ${JSON.stringify(result)}`);
+    expect(result.value.identifier.key).toBe('1234567890');
+    expect(Array.isArray(result.value.segments)).toBe(true);
+  });
+
+  it('should return an empty segments array when the personalization ID is unknown', async () => {
+    reqCtx.session[SESSION_KEY_PERSONALIZATION_ID] =
+      'unknown-id-that-has-no-segments';
+
+    const result = await provider.getPersonalizationProfile({
+      identity: { type: 'Anonymous' },
+    });
+
+    assert(result.success, `Expected success, got: ${JSON.stringify(result)}`);
+    expect(result.value.segments).toEqual([]);
+  });
+});

--- a/packages/hcl/src/test/product-associations.capability.spec.ts
+++ b/packages/hcl/src/test/product-associations.capability.spec.ts
@@ -1,0 +1,97 @@
+import 'dotenv/config';
+import type { RequestContext } from '@reactionary/core';
+import {
+  NoOpCache,
+  ProductAssociationSchema,
+  createInitialRequestContext,
+} from '@reactionary/core';
+import { describe, expect, it, beforeEach, assert } from 'vitest';
+import { HclProductAssociationsCapability } from '../capabilities/product-associations.capability.js';
+import { HclProductAssociationsFactory } from '../factories/index.js';
+import { HclClient } from '../core/client.js';
+import { getHclTestConfiguration } from './test-utils.js';
+
+// Demo server: www-latestdevauth.demo.solteq.io, storeId=41
+const testData = {
+  product: { key: 'DR-CHRS-0001' },
+};
+
+describe('HCL Product Associations Capability', () => {
+  let provider: HclProductAssociationsCapability;
+  let reqCtx: RequestContext;
+
+  beforeEach(() => {
+    reqCtx = createInitialRequestContext();
+    const config = getHclTestConfiguration();
+    const client = new HclClient(config, reqCtx);
+    provider = new HclProductAssociationsCapability(
+      new NoOpCache(),
+      reqCtx,
+      config,
+      client,
+      new HclProductAssociationsFactory(ProductAssociationSchema),
+    );
+  });
+
+  it('should return accessories for a product', async () => {
+    const result = await provider.getAccessories({
+      forProduct: testData.product,
+      numberOfAccessories: 5,
+    });
+
+    assert(result.success, `Expected success, got: ${JSON.stringify(result)}`);
+    expect(Array.isArray(result.value)).toBe(true);
+    for (const item of result.value) {
+      expect(item.associationIdentifier.key).toBeTruthy();
+      expect(item.associationReturnType).toBe('idOnly');
+      expect(item.product.key).toBeTruthy();
+    }
+  });
+
+  it('should return spareparts for a product', async () => {
+    const result = await provider.getSpareparts({
+      forProduct: testData.product,
+      numberOfSpareparts: 5,
+    });
+
+    assert(result.success, `Expected success, got: ${JSON.stringify(result)}`);
+    expect(Array.isArray(result.value)).toBe(true);
+    for (const item of result.value) {
+      expect(item.associationIdentifier.key).toBeTruthy();
+    }
+  });
+
+  it('should return replacements for a product', async () => {
+    const result = await provider.getReplacements({
+      forProduct: testData.product,
+      numberOfReplacements: 5,
+    });
+
+    assert(result.success, `Expected success, got: ${JSON.stringify(result)}`);
+    expect(Array.isArray(result.value)).toBe(true);
+    for (const item of result.value) {
+      expect(item.associationIdentifier.key).toBeTruthy();
+    }
+  });
+
+  it('should respect the count limit', async () => {
+    const result = await provider.getAccessories({
+      forProduct: testData.product,
+      numberOfAccessories: 1,
+    });
+
+    assert(result.success, `Expected success, got: ${JSON.stringify(result)}`);
+    expect(result.value.length).toBeLessThanOrEqual(1);
+  });
+
+  it('should return empty array for a product with no accessories', async () => {
+    // Products without configured associations should return empty, not error
+    const result = await provider.getAccessories({
+      forProduct: { key: 'DR-CHRS-0001' },
+      numberOfAccessories: 5,
+    });
+
+    assert(result.success, `Expected success, got: ${JSON.stringify(result)}`);
+    expect(Array.isArray(result.value)).toBe(true);
+  });
+});

--- a/packages/hcl/src/test/product-recommendations.capability.spec.ts
+++ b/packages/hcl/src/test/product-recommendations.capability.spec.ts
@@ -1,0 +1,222 @@
+import 'dotenv/config';
+import type { RequestContext } from '@reactionary/core';
+import {
+  NoOpCache,
+  ProductRecommendationSchema,
+  createInitialRequestContext,
+} from '@reactionary/core';
+import { describe, expect, it, beforeEach, assert } from 'vitest';
+import { HclProductRecommendationsCapability } from '../capabilities/product-recommendations.capability.js';
+import { HclProductRecommendationsFactory } from '../factories/index.js';
+import { HclClient } from '../core/client.js';
+import { getHclTestConfiguration } from './test-utils.js';
+
+// Demo server: www-latestdevauth.demo.solteq.io, storeId=41
+// Set HCL_ESPOTS_CONFIGURED=true in .env when the target server has the
+// Reactionary_* espots configured. Algorithm tests are skipped when not set.
+const espotsConfigured = !!process.env['HCL_ESPOTS_CONFIGURED'];
+const testData = {
+  product: { key: 'DR-CHRS-0001' },
+  category: { key: 'DiningChairs' },
+};
+
+describe('HCL Product Recommendations Capability', () => {
+  let provider: HclProductRecommendationsCapability;
+  let reqCtx: RequestContext;
+
+  beforeEach(() => {
+    reqCtx = createInitialRequestContext();
+    const config = getHclTestConfiguration();
+    const client = new HclClient(config, reqCtx);
+    provider = new HclProductRecommendationsCapability(
+      new NoOpCache(),
+      reqCtx,
+      config,
+      client,
+      new HclProductRecommendationsFactory(ProductRecommendationSchema),
+    );
+  });
+
+  describe('getRecommendations', () => {
+    it.skipIf(!espotsConfigured)(
+      'should return frequentlyBoughtTogether recommendations',
+      async () => {
+        const result = await provider.getRecommendations({
+          algorithm: 'frequentlyBoughtTogether',
+          sourceProduct: testData.product,
+          numberOfRecommendations: 4,
+        });
+
+        assert(
+          result.success,
+          `Expected success, got: ${JSON.stringify(result)}`,
+        );
+        expect(Array.isArray(result.value)).toBe(true);
+        expect(result.value.length).toBeLessThanOrEqual(4);
+        for (const item of result.value) {
+          expect(item.recommendationIdentifier.key).toBeTruthy();
+          expect(item.recommendationIdentifier.algorithm).toBe(
+            'frequentlyBoughtTogether',
+          );
+          expect(item.recommendationReturnType).toBe('idOnly');
+          if (item.recommendationReturnType === 'idOnly') {
+            expect(item.product.key).toBeTruthy();
+          }
+        }
+      },
+    );
+
+    it.skipIf(!espotsConfigured)(
+      'should return similar product recommendations',
+      async () => {
+        const result = await provider.getRecommendations({
+          algorithm: 'similar',
+          sourceProduct: testData.product,
+          numberOfRecommendations: 4,
+        });
+
+        assert(
+          result.success,
+          `Expected success, got: ${JSON.stringify(result)}`,
+        );
+        expect(Array.isArray(result.value)).toBe(true);
+        for (const item of result.value) {
+          expect(item.recommendationIdentifier.algorithm).toBe('similar');
+        }
+      },
+    );
+
+    it.skipIf(!espotsConfigured)(
+      'should return related product recommendations',
+      async () => {
+        const result = await provider.getRecommendations({
+          algorithm: 'related',
+          sourceProduct: testData.product,
+          numberOfRecommendations: 4,
+        });
+
+        assert(
+          result.success,
+          `Expected success, got: ${JSON.stringify(result)}`,
+        );
+        expect(Array.isArray(result.value)).toBe(true);
+        for (const item of result.value) {
+          expect(item.recommendationIdentifier.algorithm).toBe('related');
+        }
+      },
+    );
+
+    it.skipIf(!espotsConfigured)(
+      'should return trendingInCategory recommendations',
+      async () => {
+        const result = await provider.getRecommendations({
+          algorithm: 'trendingInCategory',
+          sourceCategory: testData.category,
+          numberOfRecommendations: 4,
+        });
+
+        assert(
+          result.success,
+          `Expected success, got: ${JSON.stringify(result)}`,
+        );
+        expect(Array.isArray(result.value)).toBe(true);
+        for (const item of result.value) {
+          expect(item.recommendationIdentifier.algorithm).toBe(
+            'trendingInCategory',
+          );
+        }
+      },
+    );
+
+    it.skipIf(!espotsConfigured)(
+      'should return popular product recommendations',
+      async () => {
+        const result = await provider.getRecommendations({
+          algorithm: 'popular',
+          numberOfRecommendations: 4,
+        });
+
+        assert(
+          result.success,
+          `Expected success, got: ${JSON.stringify(result)}`,
+        );
+        expect(Array.isArray(result.value)).toBe(true);
+        for (const item of result.value) {
+          expect(item.recommendationIdentifier.algorithm).toBe('popular');
+        }
+      },
+    );
+
+    it.skipIf(!espotsConfigured)(
+      'should return topPicks product recommendations',
+      async () => {
+        const result = await provider.getRecommendations({
+          algorithm: 'topPicks',
+          numberOfRecommendations: 4,
+        });
+
+        assert(
+          result.success,
+          `Expected success, got: ${JSON.stringify(result)}`,
+        );
+        expect(Array.isArray(result.value)).toBe(true);
+      },
+    );
+
+    it.skipIf(!espotsConfigured)(
+      'should return alsoViewed product recommendations',
+      async () => {
+        const result = await provider.getRecommendations({
+          algorithm: 'alsoViewed',
+          sourceProduct: testData.product,
+          numberOfRecommendations: 4,
+        });
+
+        assert(
+          result.success,
+          `Expected success, got: ${JSON.stringify(result)}`,
+        );
+        expect(Array.isArray(result.value)).toBe(true);
+        for (const item of result.value) {
+          expect(item.recommendationIdentifier.algorithm).toBe('alsoViewed');
+        }
+      },
+    );
+  });
+
+  describe('getCollection', () => {
+    it.skipIf(!espotsConfigured)(
+      'should return recommendations by named espot (collection)',
+      async () => {
+        const result = await provider.getCollection({
+          collectionName: 'Reactionary_Popular',
+          numberOfRecommendations: 4,
+        });
+
+        assert(
+          result.success,
+          `Expected success, got: ${JSON.stringify(result)}`,
+        );
+        expect(Array.isArray(result.value)).toBe(true);
+        expect(result.value.length).toBeLessThanOrEqual(4);
+        for (const item of result.value) {
+          expect(item.recommendationIdentifier.key).toBeTruthy();
+          expect(item.recommendationReturnType).toBe('idOnly');
+        }
+      },
+    );
+
+    it('should return empty array for a non-existent espot name', async () => {
+      const result = await provider.getCollection({
+        collectionName: 'NonExistentEspot_DoesNotExist',
+        numberOfRecommendations: 4,
+      });
+
+      assert(
+        result.success,
+        `Expected success, got: ${JSON.stringify(result)}`,
+      );
+      expect(result.value).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
Add HclAnalyticsCapability: fires WCS event calls for product views, clicks,

cart adds, and purchases; exposes getEventUrl/getEventBody extension points

Add HclProductAssociationsCapability: fetches merchandisingAssociations from

product detail endpoint for accessories, spareparts, and replacements;

exposes getProductsUrl/getProductsParams extension points

Add HclProductRecommendationsCapability: resolves algorithm-based and named

espot recommendations via WCS Transaction Service; exposes

getEspotUrl/getEspotParams extension points; generic over TFactory

Add HclPersonalizationProfileCapability: resolves member-group segments by

personalization ID from WCS segment endpoint; exposes

getSegmentsUrl/getSegmentsParams extension points

Add HclProductRecommendationsFactory (core interface + HCL implementation)

and HclProductAssociationsFactory, HclPersonalizationProfileFactory wired

via resolveCapabilityWithFactory in initialize.ts

Extend HclConfigurationSchema with associationTypes and espotNames config

Extend HclCapabilitiesSchema with the four new capability config types

Extend hcl.schema.ts with HclEspotResponse, HclSegmentResponse, and

HclAssociation types