### PR TITLE
feat(hcl): auto-upgrade anonymous callers to guest session on transac…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,4 +8,4 @@
 
 # Workflow
 - Be sure to ensure that changes lint and build.
-- Avoid introducing changes that would be breaking for any client consumer of the library without asking for clearance.
+- Avoid introducing changes that would be breaking for any client consumer of the library without asking for clearance!

--- a/packages/hcl/src/capabilities/identity.capability.ts
+++ b/packages/hcl/src/capabilities/identity.capability.ts
@@ -199,20 +199,9 @@ export class HclIdentityCapability<
   ): Promise<Result<IdentityFactoryOutput<TFactory>>> {
     debug('Registering new user: %s', payload.username);
 
-    // WCS requires a guest session before registering a new person.
-    const guest = await this.client.callPost<HclWcsIdentityResponse>(
-      this.createGuestIdentityUrl(),
-    );
-    this.storeSessionTokens(
-      guest.WCToken,
-      guest.WCTrustedToken,
-      guest.userId,
-      'guest',
-      guest.personalizationID,
-    );
-
-    // Register the person — the guest session tokens are now stored in the
-    // context so the client reads them automatically via buildHeaders().
+    // WCS requires a guest session before registering a new person. The client
+    // automatically bootstraps one via POST /guestidentity before the first
+    // transaction call when no session token is present.
     const registered = await this.client.callPut<HclWcsIdentityResponse>(
       this.registerPersonUrl(),
       this.registerPersonPayload(payload.username, payload.password),

--- a/packages/hcl/src/core/client.ts
+++ b/packages/hcl/src/core/client.ts
@@ -1,4 +1,4 @@
-import type { RequestContext } from '@reactionary/core';
+import type { GuestIdentity, RequestContext } from '@reactionary/core';
 import type { HclConfiguration } from '../schema/configuration.schema.js';
 import { getLocaleParams } from './locale-params.js';
 import type { HclWcsIdentityResponse } from '../schema/hcl.schema.js';
@@ -133,19 +133,18 @@ export class HclClient {
   }
 
   /**
-   * Ensures a guest WCS session exists before any transaction URL call.
-   * If no WCToken is present, bootstraps a guest identity via POST /guestidentity
-   * and stores the returned tokens in the request context.
+   * Bootstraps a guest WCS session for whitelisted transaction endpoints.
    *
-   * Skipped for auth-bootstrap endpoints (/guestidentity, /loginidentity) to
-   * prevent infinite recursion and avoid pre-empting explicit auth flows.
-   * Skipped entirely for catalog (non-transaction) URLs.
+   * Only fires when no WCToken is present AND the URL targets one of the
+   * whitelisted capabilities (cart, order, profile). Catalog URLs and
+   * non-whitelisted transaction paths are left as anonymous so that browsing
+   * sessions never create guest-identity rows in the WCS database.
+   *
+   * @see requiresGuestSession
    */
   protected async ensureGuestSession(url: string): Promise<void> {
-    if (!url.startsWith(this.transactionBaseUrl)) return;
+    if (!this.requiresGuestSession(url)) return;
     if (this.context.session[SESSION_KEY_WC_TOKEN]) return;
-    if (url.includes('/guestidentity') || url.includes('/loginidentity'))
-      return;
 
     const guestUrl = `${this.transactionBaseUrl}/guestidentity`;
     const response = await fetch(guestUrl, {
@@ -172,6 +171,36 @@ export class HclClient {
     } else {
       delete this.context.session[SESSION_KEY_PERSONALIZATION_ID];
     }
+    // Reflect the upgrade in the structured identity context so capability-layer
+    // callers (e.g. getSelf) immediately see the correct identity type.
+    this.context.session.identityContext.identity = {
+      type: 'Guest',
+      id: { userId: data.userId },
+    } satisfies GuestIdentity;
+    this.context.session.identityContext.lastUpdated = new Date();
+  }
+
+  /**
+   * Returns true when `url` targets a transaction endpoint that should trigger
+   * automatic guest-session bootstrapping.
+   *
+   * Only the following path prefixes are whitelisted — other transaction calls
+   * (price rules, espots, segments, inventory, …) must NOT create guest-identity
+   * rows in the WCS database for anonymous browsing sessions.
+   *
+   * Override in project-specific subclasses to adjust the whitelist.
+   */
+  protected requiresGuestSession(url: string): boolean {
+    if (!url.startsWith(this.transactionBaseUrl)) return false;
+    const path = url.slice(this.transactionBaseUrl.length);
+    // /cart   — cart and checkout capabilities
+    // /order  — order and order-search capabilities
+    // /person — profile capability
+    return (
+      path.startsWith('/cart') ||
+      path.startsWith('/order') ||
+      path.startsWith('/person')
+    );
   }
 
   /**

--- a/packages/hcl/src/core/client.ts
+++ b/packages/hcl/src/core/client.ts
@@ -71,7 +71,6 @@ export class HclClient {
     params?: URLSearchParams,
     opts?: { allowUndefined?: boolean },
   ): Promise<T | undefined> {
-    await this.ensureGuestSession(url);
     const merged = this.buildParams(params);
     const query = merged.toString() ? `?${merged.toString()}` : '';
     const response = await fetch(`${url}${query}`, {
@@ -120,7 +119,6 @@ export class HclClient {
   }
 
   async callDelete(url: string, opts?: { ignore404?: boolean }): Promise<void> {
-    await this.ensureGuestSession(url);
     const response = await fetch(url, {
       method: 'DELETE',
       headers: this.buildHeaders(),

--- a/packages/hcl/src/core/client.ts
+++ b/packages/hcl/src/core/client.ts
@@ -1,8 +1,11 @@
 import type { RequestContext } from '@reactionary/core';
 import type { HclConfiguration } from '../schema/configuration.schema.js';
 import { getLocaleParams } from './locale-params.js';
+import type { HclWcsIdentityResponse } from '../schema/hcl.schema.js';
 import {
+  SESSION_KEY_IDENTITY_TYPE,
   SESSION_KEY_PERSONALIZATION_ID,
+  SESSION_KEY_USER_ID,
   SESSION_KEY_WC_TOKEN,
   SESSION_KEY_WC_TRUSTED_TOKEN,
 } from './session-keys.js';
@@ -43,7 +46,10 @@ export class HclClient {
     protected readonly context: RequestContext,
   ) {
     const origin = config.apiUrl.replace(/\/+$/, '');
-    const searchOrigin =  (config.searchApiUrl ?? config.apiUrl).replace(/\/+$/, '')
+    const searchOrigin = (config.searchApiUrl ?? config.apiUrl).replace(
+      /\/+$/,
+      '',
+    );
     this.catalogBaseUrl = `${searchOrigin}/search/resources`;
     this.transactionBaseUrl = `${origin}/wcs/resources/store/${config.storeId}`;
   }
@@ -65,6 +71,7 @@ export class HclClient {
     params?: URLSearchParams,
     opts?: { allowUndefined?: boolean },
   ): Promise<T | undefined> {
+    await this.ensureGuestSession(url);
     const merged = this.buildParams(params);
     const query = merged.toString() ? `?${merged.toString()}` : '';
     const response = await fetch(`${url}${query}`, {
@@ -81,6 +88,7 @@ export class HclClient {
   }
 
   async callPost<T>(url: string, body: unknown = {}): Promise<T> {
+    await this.ensureGuestSession(url);
     const response = await fetch(url, {
       method: 'POST',
       headers: { ...this.buildHeaders(), 'Content-Type': 'application/json' },
@@ -96,6 +104,7 @@ export class HclClient {
   }
 
   async callPut<T>(url: string, body: unknown): Promise<T> {
+    await this.ensureGuestSession(url);
     const response = await fetch(url, {
       method: 'PUT',
       headers: { ...this.buildHeaders(), 'Content-Type': 'application/json' },
@@ -111,6 +120,7 @@ export class HclClient {
   }
 
   async callDelete(url: string, opts?: { ignore404?: boolean }): Promise<void> {
+    await this.ensureGuestSession(url);
     const response = await fetch(url, {
       method: 'DELETE',
       headers: this.buildHeaders(),
@@ -119,6 +129,48 @@ export class HclClient {
       throw new Error(
         `HCL DELETE ${url} error ${response.status} ${response.statusText}`,
       );
+    }
+  }
+
+  /**
+   * Ensures a guest WCS session exists before any transaction URL call.
+   * If no WCToken is present, bootstraps a guest identity via POST /guestidentity
+   * and stores the returned tokens in the request context.
+   *
+   * Skipped for auth-bootstrap endpoints (/guestidentity, /loginidentity) to
+   * prevent infinite recursion and avoid pre-empting explicit auth flows.
+   * Skipped entirely for catalog (non-transaction) URLs.
+   */
+  protected async ensureGuestSession(url: string): Promise<void> {
+    if (!url.startsWith(this.transactionBaseUrl)) return;
+    if (this.context.session[SESSION_KEY_WC_TOKEN]) return;
+    if (url.includes('/guestidentity') || url.includes('/loginidentity'))
+      return;
+
+    const guestUrl = `${this.transactionBaseUrl}/guestidentity`;
+    const response = await fetch(guestUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      body: JSON.stringify({}),
+    });
+    if (!response.ok) {
+      throw new Error(
+        `HCL guest identity bootstrap failed: ${response.status} ${response.statusText}`,
+      );
+    }
+    const data = (await response.json()) as HclWcsIdentityResponse;
+    this.context.session[SESSION_KEY_WC_TOKEN] = data.WCToken;
+    this.context.session[SESSION_KEY_WC_TRUSTED_TOKEN] = data.WCTrustedToken;
+    this.context.session[SESSION_KEY_USER_ID] = data.userId;
+    this.context.session[SESSION_KEY_IDENTITY_TYPE] = 'guest';
+    if (data.personalizationID) {
+      this.context.session[SESSION_KEY_PERSONALIZATION_ID] =
+        data.personalizationID;
+    } else {
+      delete this.context.session[SESSION_KEY_PERSONALIZATION_ID];
     }
   }
 

--- a/packages/hcl/src/test/auto-guest-session.spec.ts
+++ b/packages/hcl/src/test/auto-guest-session.spec.ts
@@ -70,6 +70,9 @@ describe('HCL auto guest-session upgrade', () => {
     expect(reqCtx.session['hcl.userId']).toBeTruthy();
     expect(reqCtx.session['hcl.identityType']).toBe('guest');
 
+    // The structured identity context must reflect the upgrade.
+    expect(reqCtx.session.identityContext.identity.type).toBe('Guest');
+
     // Cart operation itself must have succeeded.
     expect(result.value.items).toHaveLength(1);
     expect(result.value.items[0].variant.sku).toBe(testData.partNumber);

--- a/packages/hcl/src/test/auto-guest-session.spec.ts
+++ b/packages/hcl/src/test/auto-guest-session.spec.ts
@@ -1,0 +1,108 @@
+// Demo server: www-latestdevauth.demo.solteq.io, storeId=41
+import 'dotenv/config';
+import type { RequestContext } from '@reactionary/core';
+import {
+  CartIdentifierSchema,
+  CartPaginatedSearchResultSchema,
+  CartSchema,
+  NoOpCache,
+  createInitialRequestContext,
+} from '@reactionary/core';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { HclCartCapability } from '../capabilities/cart.capability.js';
+import { HclClient } from '../core/client.js';
+import { HclCartFactory } from '../factories/index.js';
+import { getHclTestConfiguration } from './test-utils.js';
+
+const testData = {
+  partNumber: 'DR-CHRS-0001-0001',
+};
+
+describe('HCL auto guest-session upgrade', () => {
+  let provider: HclCartCapability;
+  let reqCtx: RequestContext;
+
+  beforeEach(() => {
+    // No session tokens set — the client bootstraps a guest session on the
+    // first transaction call via ensureGuestSession().
+    reqCtx = createInitialRequestContext();
+    const config = getHclTestConfiguration();
+    const hclClient = new HclClient(config, reqCtx);
+    provider = new HclCartCapability(
+      new NoOpCache(),
+      reqCtx,
+      config,
+      hclClient,
+      new HclCartFactory(
+        CartSchema,
+        CartIdentifierSchema,
+        CartPaginatedSearchResultSchema,
+      ),
+    );
+  });
+
+  afterEach(async () => {
+    try {
+      await provider.deleteCart({ cart: { key: '' } });
+    } catch {
+      // ignore — cart may already be gone or was never created
+    }
+  });
+
+  it('should bootstrap a guest session and succeed without prior authentication', async () => {
+    expect(reqCtx.session['hcl.WCToken']).toBeUndefined();
+
+    const result = await provider.add({
+      cart: { key: '' },
+      variant: { sku: testData.partNumber },
+      quantity: 1,
+    });
+
+    expect(
+      result.success,
+      `Expected success, got: ${JSON.stringify(result)}`,
+    ).toBe(true);
+    if (!result.success) return;
+
+    // Session must now contain guest tokens written by ensureGuestSession.
+    expect(reqCtx.session['hcl.WCToken']).toBeTruthy();
+    expect(reqCtx.session['hcl.WCTrustedToken']).toBeTruthy();
+    expect(reqCtx.session['hcl.userId']).toBeTruthy();
+    expect(reqCtx.session['hcl.identityType']).toBe('guest');
+
+    // Cart operation itself must have succeeded.
+    expect(result.value.items).toHaveLength(1);
+    expect(result.value.items[0].variant.sku).toBe(testData.partNumber);
+    expect(result.value.items[0].quantity).toBe(1);
+  });
+
+  it('should reuse the existing guest session on subsequent calls', async () => {
+    // First call — no token present, auto-upgrade fires.
+    const firstResult = await provider.add({
+      cart: { key: '' },
+      variant: { sku: testData.partNumber },
+      quantity: 1,
+    });
+    expect(
+      firstResult.success,
+      `Expected success, got: ${JSON.stringify(firstResult)}`,
+    ).toBe(true);
+
+    const tokenAfterFirst = reqCtx.session['hcl.WCToken'] as string;
+    expect(tokenAfterFirst).toBeTruthy();
+
+    // Second call — token already present, ensureGuestSession must skip.
+    const secondResult = await provider.add({
+      cart: { key: '' },
+      variant: { sku: testData.partNumber },
+      quantity: 1,
+    });
+    expect(
+      secondResult.success,
+      `Expected success, got: ${JSON.stringify(secondResult)}`,
+    ).toBe(true);
+
+    // The WCToken must be unchanged — the same guest session was reused.
+    expect(reqCtx.session['hcl.WCToken']).toBe(tokenAfterFirst);
+  });
+});

--- a/packages/hcl/src/test/order-search.capability.spec.ts
+++ b/packages/hcl/src/test/order-search.capability.spec.ts
@@ -52,6 +52,7 @@ describe.skipIf(!hasCredentials)('HCL Order Search Capability', () => {
     const result = await provider.queryByTerm({
       search: {
         term: '',
+        filters: [],
         paginationOptions: { pageSize: 10, pageNumber: 1 },
       },
     });
@@ -66,6 +67,7 @@ describe.skipIf(!hasCredentials)('HCL Order Search Capability', () => {
     const result = await provider.queryByTerm({
       search: {
         term: '',
+        filters: [],
         paginationOptions: { pageSize: 5, pageNumber: 2 },
       },
     });
@@ -77,6 +79,7 @@ describe.skipIf(!hasCredentials)('HCL Order Search Capability', () => {
     const result = await provider.queryByTerm({
       search: {
         term: '',
+        filters: [],
         paginationOptions: { pageSize: 10, pageNumber: 9999 },
       },
     });

--- a/packages/hcl/src/test/profile.capability.spec.ts
+++ b/packages/hcl/src/test/profile.capability.spec.ts
@@ -50,7 +50,9 @@ describe.skipIf(!hasCredentials)('HCL Profile Capability', () => {
   });
 
   it('should return the authenticated user profile', async () => {
-    const result = await provider.getById({});
+    const result = await provider.getById({
+      identifier: { userId: reqCtx.session['hcl.userId'] as string },
+    });
     expect(result.success).toBe(true);
     if (!result.success) return;
 
@@ -58,7 +60,9 @@ describe.skipIf(!hasCredentials)('HCL Profile Capability', () => {
   });
 
   it('should update profile email and phone', async () => {
-    const profileResult = await provider.getById({});
+    const profileResult = await provider.getById({
+      identifier: { userId: reqCtx.session['hcl.userId'] as string },
+    });
     expect(profileResult.success).toBe(true);
     if (!profileResult.success) return;
 
@@ -74,12 +78,15 @@ describe.skipIf(!hasCredentials)('HCL Profile Capability', () => {
 
   it('should add a shipping address', async () => {
     const result = await provider.addShippingAddress({
+      identifier: { userId: reqCtx.session['hcl.userId'] as string },
       address: {
         identifier: { nickName: 'TestAddr_' + Date.now() },
         firstName: 'Test',
         lastName: 'User',
         streetAddress: 'Test Street 1',
+        streetNumber: '',
         city: 'Helsinki',
+        region: '',
         postalCode: '00100',
         countryCode: 'FI',
       },
@@ -88,11 +95,13 @@ describe.skipIf(!hasCredentials)('HCL Profile Capability', () => {
   });
 
   it('should update an existing shipping address', async () => {
-    const profileResult = await provider.getById({});
+    const profileResult = await provider.getById({
+      identifier: { userId: reqCtx.session['hcl.userId'] as string },
+    });
     expect(profileResult.success).toBe(true);
     if (!profileResult.success) return;
 
-    const addresses = profileResult.value.shippingAddresses ?? [];
+    const addresses = profileResult.value.alternateShippingAddresses ?? [];
     if (addresses.length === 0) {
       console.warn('No shipping addresses to update — skipping');
       return;
@@ -100,6 +109,7 @@ describe.skipIf(!hasCredentials)('HCL Profile Capability', () => {
 
     const addr = addresses[0];
     const result = await provider.updateShippingAddress({
+      identifier: profileResult.value.identifier,
       address: { ...addr, city: 'Espoo' },
     });
     expect(result.success).toBe(true);
@@ -107,12 +117,15 @@ describe.skipIf(!hasCredentials)('HCL Profile Capability', () => {
 
   it('should return NotFound when updating a non-existent address', async () => {
     const result = await provider.updateShippingAddress({
+      identifier: { userId: reqCtx.session['hcl.userId'] as string },
       address: {
         identifier: { nickName: 'DoesNotExist_' + Date.now() },
         firstName: 'Ghost',
         lastName: 'User',
         streetAddress: 'Nowhere',
+        streetNumber: '',
         city: 'Void',
+        region: '',
         postalCode: '00000',
         countryCode: 'FI',
       },
@@ -126,12 +139,15 @@ describe.skipIf(!hasCredentials)('HCL Profile Capability', () => {
     // Add one first so we have something to remove
     const nick = 'ToDelete_' + Date.now();
     const addResult = await provider.addShippingAddress({
+      identifier: { userId: reqCtx.session['hcl.userId'] as string },
       address: {
         identifier: { nickName: nick },
         firstName: 'Delete',
         lastName: 'Me',
         streetAddress: 'Temp St 1',
+        streetNumber: '',
         city: 'Helsinki',
+        region: '',
         postalCode: '00100',
         countryCode: 'FI',
       },
@@ -139,6 +155,7 @@ describe.skipIf(!hasCredentials)('HCL Profile Capability', () => {
     expect(addResult.success).toBe(true);
 
     const removeResult = await provider.removeShippingAddress({
+      identifier: { userId: reqCtx.session['hcl.userId'] as string },
       addressIdentifier: { nickName: nick },
     });
     expect(removeResult.success).toBe(true);
@@ -146,6 +163,7 @@ describe.skipIf(!hasCredentials)('HCL Profile Capability', () => {
 
   it('should return NotFound when removing a non-existent address', async () => {
     const result = await provider.removeShippingAddress({
+      identifier: { userId: reqCtx.session['hcl.userId'] as string },
       addressIdentifier: { nickName: 'DoesNotExist_' + Date.now() },
     });
     expect(result.success).toBe(false);
@@ -154,17 +172,20 @@ describe.skipIf(!hasCredentials)('HCL Profile Capability', () => {
   });
 
   it('should set a default shipping address', async () => {
-    const profileResult = await provider.getById({});
+    const profileResult = await provider.getById({
+      identifier: { userId: reqCtx.session['hcl.userId'] as string },
+    });
     expect(profileResult.success).toBe(true);
     if (!profileResult.success) return;
 
-    const addresses = profileResult.value.shippingAddresses ?? [];
+    const addresses = profileResult.value.alternateShippingAddresses ?? [];
     if (addresses.length === 0) {
       console.warn('No shipping addresses to make default — skipping');
       return;
     }
 
     const result = await provider.makeShippingAddressDefault({
+      identifier: profileResult.value.identifier,
       addressIdentifier: addresses[0].identifier,
     });
     expect(result.success).toBe(true);
@@ -172,12 +193,15 @@ describe.skipIf(!hasCredentials)('HCL Profile Capability', () => {
 
   it('should set the billing address (upsert)', async () => {
     const result = await provider.setBillingAddress({
+      identifier: { userId: reqCtx.session['hcl.userId'] as string },
       address: {
         identifier: { nickName: 'Billing' },
         firstName: 'Billing',
         lastName: 'User',
         streetAddress: 'Billing Ave 1',
+        streetNumber: '',
         city: 'Helsinki',
+        region: '',
         postalCode: '00100',
         countryCode: 'FI',
       },


### PR DESCRIPTION
…tion API calls

When any HCL transaction URL is called without a WCToken in session, HclClient.ensureGuestSession() now automatically POSTs to /guestidentity and stores the returned tokens (WCToken, WCTrustedToken, userId, identityType=guest, personalizationID) in the request context before the original request proceeds.

- Add HclClient.ensureGuestSession() called at the top of callGet, callPost, callPut and callDelete for transaction URLs only
- Skip upgrade for /guestidentity and /loginidentity endpoints to prevent infinite recursion and avoid pre-empting explicit auth flows
- Remove redundant explicit guest creation from register() — the callPut to /person/@self now triggers the upgrade automatically
- Add auto-guest-session.spec.ts integration test covering bootstrap on first cart add and session reuse on subsequent calls

fix(hcl): update test fixtures to match current schema

- order-search spec: add required filters: [] to all queryByTerm calls
- profile spec: pass identifier to getById and all address mutations; add required streetNumber/region to address fixtures; replace non-existent shippingAddresses with alternateShippingAddresses