### PR TITLE
feat(lipscore): add @reactionary/lipscore package with ProductReviews…

### DIFF
--- a/packages/lipscore/eslint.config.mjs
+++ b/packages/lipscore/eslint.config.mjs
@@ -1,0 +1,23 @@
+import baseConfig from '../../eslint.config.mjs';
+
+export default [
+  ...baseConfig,
+  {
+    files: ['**/*.json'],
+    rules: {
+      '@nx/dependency-checks': [
+        'error',
+        {
+          ignoredFiles: [
+            '{projectRoot}/eslint.config.{js,cjs,mjs,ts,cts,mts}',
+            '{projectRoot}/esbuild.config.{js,ts,mjs,mts}',
+            '{projectRoot}/vite.config.{js,ts,mjs,mts}',
+          ],
+        },
+      ],
+    },
+    languageOptions: {
+      parser: await import('jsonc-eslint-parser'),
+    },
+  },
+];

--- a/packages/lipscore/package.json
+++ b/packages/lipscore/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@reactionary/lipscore",
+  "version": "0.0.1",
+  "type": "module",
+  "main": "./index.js",
+  "types": "./src/index.d.ts",
+  "dependencies": {
+    "@reactionary/core": "0.0.1",
+    "zod": "4.1.9"
+  },
+  "devDependencies": {
+    "@nx/vite": "22.4.5",
+    "vitest": "^4.0.9"
+  },
+  "sideEffects": false
+}

--- a/packages/lipscore/project.json
+++ b/packages/lipscore/project.json
@@ -1,0 +1,33 @@
+{
+  "name": "lipscore",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/lipscore/src",
+  "projectType": "library",
+  "release": {
+    "version": {
+      "manifestRootsToUpdate": ["dist/{projectRoot}"],
+      "currentVersionResolver": "git-tag",
+      "fallbackCurrentVersionResolver": "disk"
+    }
+  },
+  "tags": [],
+  "targets": {
+    "build": {
+      "executor": "@nx/esbuild:esbuild",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/packages/lipscore",
+        "main": "packages/lipscore/src/index.ts",
+        "tsConfig": "packages/lipscore/tsconfig.lib.json",
+        "assets": ["packages/lipscore/*.md"],
+        "format": ["esm"],
+        "bundle": false
+      }
+    },
+    "nx-release-publish": {
+      "options": {
+        "packageRoot": "dist/{projectRoot}"
+      }
+    }
+  }
+}

--- a/packages/lipscore/src/capabilities/index.ts
+++ b/packages/lipscore/src/capabilities/index.ts
@@ -1,0 +1,1 @@
+export * from './product-reviews.capability.js';

--- a/packages/lipscore/src/capabilities/product-reviews.capability.ts
+++ b/packages/lipscore/src/capabilities/product-reviews.capability.ts
@@ -1,0 +1,128 @@
+import {
+  ProductReviewPaginatedResultSchema,
+  ProductRatingSummarySchema,
+  ProductReviewSchema,
+  ProductReviewsCapability,
+  Reactionary,
+  error,
+  success,
+  type Cache,
+  type InvalidInputError,
+  type ProductReviewMutationSubmit,
+  type ProductReviewsFactory,
+  type ProductReviewsFactoryRatingOutput,
+  type ProductReviewsFactoryReviewOutput,
+  type ProductReviewsFactoryReviewPaginatedOutput,
+  type ProductReviewsFactoryWithOutput,
+  type ProductReviewsGetRatingSummaryQuery,
+  type ProductReviewsListQuery,
+  type RequestContext,
+  type Result,
+} from '@reactionary/core';
+import { LipscoreProductsResponseSchema } from '../schema/lipscore.schema.js';
+import type { LipscoreConfiguration } from '../schema/configuration.schema.js';
+import type { LipscoreClient } from '../core/client.js';
+import type { LipscoreProductReviewsFactory } from '../factories/product-reviews/product-reviews.factory.js';
+
+export class LipscoreProductReviewsCapability<
+  TFactory extends ProductReviewsFactory = LipscoreProductReviewsFactory,
+> extends ProductReviewsCapability<
+  ProductReviewsFactoryRatingOutput<TFactory>,
+  ProductReviewsFactoryReviewPaginatedOutput<TFactory>,
+  ProductReviewsFactoryReviewOutput<TFactory>
+> {
+  constructor(
+    cache: Cache,
+    context: RequestContext,
+    protected readonly config: LipscoreConfiguration,
+    protected readonly client: LipscoreClient,
+    protected readonly factory: ProductReviewsFactoryWithOutput<TFactory>,
+  ) {
+    super(cache, context);
+  }
+
+  @Reactionary({
+    outputSchema: ProductRatingSummarySchema,
+    cache: true,
+    cacheTimeToLiveInSeconds: 300,
+    currencyDependentCaching: false,
+    localeDependentCaching: false,
+  })
+  public override async getRatingSummary(
+    query: ProductReviewsGetRatingSummaryQuery,
+  ): Promise<Result<ProductReviewsFactoryRatingOutput<TFactory>>> {
+    const response = await this.client.callGet(
+      this.getReviewsUrl(),
+      this.getRatingSummaryParams(query.product.key),
+      LipscoreProductsResponseSchema,
+    );
+
+    return success(this.factory.parseRatingSummary(this.context, response));
+  }
+
+  @Reactionary({
+    outputSchema: ProductReviewPaginatedResultSchema,
+    cache: true,
+    cacheTimeToLiveInSeconds: 60,
+    currencyDependentCaching: false,
+    localeDependentCaching: false,
+  })
+  public override async findReviews(
+    query: ProductReviewsListQuery,
+  ): Promise<Result<ProductReviewsFactoryReviewPaginatedOutput<TFactory>>> {
+    const pageSize = query.paginationOptions?.pageSize ?? 10;
+    const pageNumber = query.paginationOptions?.pageNumber ?? 1;
+
+    const response = await this.client.callGet(
+      this.getReviewsUrl(),
+      this.getReviewsParams(query.product.key),
+      LipscoreProductsResponseSchema,
+    );
+
+    return success(
+      this.factory.parseReviewPaginatedResult(this.context, {
+        response,
+        productKey: query.product.key,
+        pageSize,
+        pageNumber,
+      }),
+    );
+  }
+
+  @Reactionary({
+    outputSchema: ProductReviewSchema,
+    cache: false,
+    cacheTimeToLiveInSeconds: 0,
+    currencyDependentCaching: false,
+    localeDependentCaching: false,
+  })
+  public override async submitReview(
+    mutation: ProductReviewMutationSubmit,
+  ): Promise<Result<ProductReviewsFactoryReviewOutput<TFactory>>> {
+    void mutation;
+    return error<InvalidInputError>({
+      type: 'InvalidInput',
+      error:
+        'Review submission is handled via the Lipscore widget and is not available through this API.',
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Extension points — override in subclasses to customise API calls
+  // ---------------------------------------------------------------------------
+
+  protected getReviewsUrl(): string {
+    return `${this.client.baseUrl}/products`;
+  }
+
+  protected getReviewsParams(productId: string): URLSearchParams {
+    const params = new URLSearchParams();
+    params.set('internal_id[]', productId);
+    params.set('fields', 'reviews');
+    return params;
+  }
+
+  protected getRatingSummaryParams(productId: string): URLSearchParams {
+    return this.getReviewsParams(productId);
+  }
+}

--- a/packages/lipscore/src/core/client.ts
+++ b/packages/lipscore/src/core/client.ts
@@ -1,0 +1,46 @@
+import type { RequestContext } from '@reactionary/core';
+import type { LipscoreConfiguration } from '../schema/configuration.schema.js';
+
+export class LipscoreClient {
+  readonly baseUrl: string;
+
+  constructor(
+    protected readonly config: LipscoreConfiguration,
+    protected readonly context: RequestContext,
+  ) {
+    this.baseUrl = config.apiUrl.replace(/\/+$/, '');
+  }
+
+  async callGet<T>(
+    url: string,
+    params: URLSearchParams,
+    schema: { parse(data: unknown): T },
+  ): Promise<T> {
+    const merged = this.buildParams(params);
+    const query = merged.toString() ? `?${merged.toString()}` : '';
+    const response = await fetch(`${url}${query}`, {
+      headers: this.buildHeaders(),
+    });
+    if (!response.ok) {
+      throw new Error(
+        `Lipscore GET ${url} error ${response.status} ${response.statusText}`,
+      );
+    }
+    const json: unknown = await response.json();
+    return schema.parse(json);
+  }
+
+  protected buildParams(params: URLSearchParams): URLSearchParams {
+    const merged = new URLSearchParams(params);
+    if (!merged.has('api_key')) merged.set('api_key', this.config.apiKey);
+    return merged;
+  }
+
+  protected buildHeaders(): Record<string, string> {
+    const headers: Record<string, string> = {};
+    if (this.config.apiSecret) {
+      headers['X-Authorization'] = this.config.apiSecret;
+    }
+    return headers;
+  }
+}

--- a/packages/lipscore/src/core/initialize.ts
+++ b/packages/lipscore/src/core/initialize.ts
@@ -1,0 +1,69 @@
+import type { Cache, RequestContext } from '@reactionary/core';
+import {
+  ProductRatingSummarySchema,
+  ProductReviewPaginatedResultSchema,
+  ProductReviewSchema,
+} from '@reactionary/core';
+import { LipscoreProductReviewsCapability } from '../capabilities/product-reviews.capability.js';
+import { LipscoreProductReviewsFactory } from '../factories/product-reviews/product-reviews.factory.js';
+import type {
+  LipscoreCapabilities,
+  LipscoreProductReviewsCapabilityConfig,
+} from '../schema/capabilities.schema.js';
+import { LipscoreCapabilitiesSchema } from '../schema/capabilities.schema.js';
+import type { LipscoreConfiguration } from '../schema/configuration.schema.js';
+import { LipscoreConfigurationSchema } from '../schema/configuration.schema.js';
+import { LipscoreClient } from './client.js';
+import {
+  type LipscoreClientFromCapabilities,
+  resolveCapabilityWithFactory,
+} from './initialize.types.js';
+
+export function withLipscoreCapabilities<T extends LipscoreCapabilities>(
+  configuration: LipscoreConfiguration,
+  capabilities: T,
+) {
+  return (
+    cache: Cache,
+    context: RequestContext,
+  ): LipscoreClientFromCapabilities<T> => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const client: any = {};
+
+    const config = LipscoreConfigurationSchema.parse(configuration);
+    const caps = LipscoreCapabilitiesSchema.parse(capabilities);
+    const lipscoreClient = new LipscoreClient(config, context);
+
+    if (caps.productReviews?.enabled) {
+      client.productReviews = resolveCapabilityWithFactory(
+        capabilities.productReviews as
+          | LipscoreProductReviewsCapabilityConfig
+          | undefined,
+        {
+          factory: new LipscoreProductReviewsFactory(
+            ProductRatingSummarySchema,
+            ProductReviewSchema,
+            ProductReviewPaginatedResultSchema,
+          ),
+          capability: (args) =>
+            new LipscoreProductReviewsCapability(
+              args.cache,
+              args.context,
+              args.config,
+              args.client,
+              args.factory,
+            ),
+        },
+        (factory) => ({
+          cache,
+          context,
+          config,
+          client: lipscoreClient,
+          factory,
+        }),
+      );
+    }
+
+    return client;
+  };
+}

--- a/packages/lipscore/src/core/initialize.types.ts
+++ b/packages/lipscore/src/core/initialize.types.ts
@@ -1,0 +1,88 @@
+import type {
+  ClientFromCapabilities,
+  ProductReviewsFactory,
+} from '@reactionary/core';
+import type { LipscoreCapabilities } from '../schema/capabilities.schema.js';
+import type { LipscoreProductReviewsFactory } from '../factories/product-reviews/product-reviews.factory.js';
+import type { LipscoreProductReviewsCapability } from '../capabilities/product-reviews.capability.js';
+
+type EnabledCapability<TCapability> = TCapability extends { enabled: true }
+  ? true
+  : false;
+
+type NormalizeConfiguredCapabilities<T extends LipscoreCapabilities> = Omit<
+  T,
+  'productReviews'
+> & {
+  productReviews?: EnabledCapability<T['productReviews']>;
+};
+
+type ExtractCapabilityFactory<TCapability, TContract, TDefaultFactory> =
+  TCapability extends { enabled: true; factory?: infer TFactory }
+    ? TFactory extends TContract
+      ? TFactory
+      : TDefaultFactory
+    : TDefaultFactory;
+
+type ExtractCapabilityImplementation<TCapability, TDefaultCapability> =
+  TCapability extends { enabled: true; capability?: infer TCapabilityFactory }
+    ? TCapabilityFactory extends (
+        ...args: unknown[]
+      ) => infer TResolvedCapability
+      ? TResolvedCapability
+      : TDefaultCapability
+    : TDefaultCapability;
+
+type CapabilityOverride<
+  TCapability,
+  TKey extends string,
+  TResolvedCapability,
+> = TCapability extends { enabled: true }
+  ? { [K in TKey]: TResolvedCapability }
+  : Record<never, never>;
+
+type ProductReviewsFactoryFor<T extends LipscoreCapabilities> =
+  ExtractCapabilityFactory<
+    T['productReviews'],
+    ProductReviewsFactory,
+    LipscoreProductReviewsFactory
+  >;
+
+type ProductReviewsCapabilityFor<T extends LipscoreCapabilities> =
+  ExtractCapabilityImplementation<
+    T['productReviews'],
+    LipscoreProductReviewsCapability<ProductReviewsFactoryFor<T>>
+  >;
+
+export type LipscoreClientFromCapabilities<T extends LipscoreCapabilities> =
+  Omit<
+    ClientFromCapabilities<NormalizeConfiguredCapabilities<T>>,
+    'productReviews'
+  > &
+    CapabilityOverride<
+      T['productReviews'],
+      'productReviews',
+      ProductReviewsCapabilityFor<T>
+    >;
+
+export function resolveCapabilityWithFactory<
+  TFactory,
+  TResolvedCapability,
+  TCapabilityArgs,
+>(
+  capability:
+    | {
+        factory?: TFactory;
+        capability?: (args: TCapabilityArgs) => TResolvedCapability;
+      }
+    | undefined,
+  defaults: {
+    factory: TFactory;
+    capability: (args: TCapabilityArgs) => TResolvedCapability;
+  },
+  buildCapabilityArgs: (factory: TFactory) => TCapabilityArgs,
+): TResolvedCapability {
+  const factory = capability?.factory ?? defaults.factory;
+  const capabilityFactory = capability?.capability ?? defaults.capability;
+  return capabilityFactory(buildCapabilityArgs(factory as TFactory));
+}

--- a/packages/lipscore/src/factories/index.ts
+++ b/packages/lipscore/src/factories/index.ts
@@ -1,0 +1,1 @@
+export * from './product-reviews/product-reviews.factory.js';

--- a/packages/lipscore/src/factories/product-reviews/product-reviews.factory.ts
+++ b/packages/lipscore/src/factories/product-reviews/product-reviews.factory.ts
@@ -1,0 +1,132 @@
+import type * as z from 'zod';
+import type {
+  AnyProductRatingSummarySchema,
+  AnyProductReviewPaginatedSchema,
+  AnyProductReviewSchema,
+  ProductReviewsFactory,
+  RequestContext,
+  ProductRatingSummarySchema,
+  ProductReviewSchema,
+  ProductReviewPaginatedResultSchema,
+} from '@reactionary/core';
+import type {
+  LipscoreReview,
+  LipscoreProductsResponse,
+} from '../../schema/lipscore.schema.js';
+
+export interface LipscoreReviewsPage {
+  response: LipscoreProductsResponse;
+  productKey: string;
+  pageSize: number;
+  pageNumber: number;
+}
+
+export class LipscoreProductReviewsFactory<
+  TRatingSummarySchema extends
+    AnyProductRatingSummarySchema = typeof ProductRatingSummarySchema,
+  TReviewSchema extends AnyProductReviewSchema = typeof ProductReviewSchema,
+  TReviewPaginatedSchema extends
+    AnyProductReviewPaginatedSchema = typeof ProductReviewPaginatedResultSchema,
+> implements
+    ProductReviewsFactory<
+      TRatingSummarySchema,
+      TReviewSchema,
+      TReviewPaginatedSchema
+    >
+{
+  constructor(
+    public readonly ratingSummarySchema: TRatingSummarySchema,
+    public readonly reviewSchema: TReviewSchema,
+    public readonly reviewPaginatedSchema: TReviewPaginatedSchema,
+  ) {}
+
+  parseRatingSummary(
+    _context: RequestContext,
+    data: LipscoreProductsResponse,
+  ): z.output<TRatingSummarySchema> {
+    const product = data[0];
+    const reviews = product?.reviews ?? [];
+
+    if (reviews.length === 0) {
+      return this.ratingSummarySchema.parse({
+        identifier: { product: { key: String(product?.internal_id ?? '') } },
+        averageRating: 0,
+        totalRatings: undefined,
+        ratingDistribution: undefined,
+      });
+    }
+
+    const total = reviews.length;
+    const sum = reviews.reduce((acc, r) => acc + r.rating, 0);
+    const averageRating = Math.round((sum / total) * 100) / 100;
+
+    const distribution: Record<string, number> = {
+      '1': 0,
+      '2': 0,
+      '3': 0,
+      '4': 0,
+      '5': 0,
+    };
+    for (const review of reviews) {
+      const key = String(Math.min(5, Math.max(1, Math.round(review.rating))));
+      distribution[key] = (distribution[key] ?? 0) + 1;
+    }
+
+    return this.ratingSummarySchema.parse({
+      identifier: { product: { key: String(product?.internal_id ?? '') } },
+      averageRating,
+      totalRatings: total,
+      ratingDistribution: distribution,
+    });
+  }
+
+  parseReview(
+    _context: RequestContext,
+    data: LipscoreReview,
+  ): z.output<TReviewSchema> {
+    return this.reviewSchema.parse({
+      identifier: { key: String(data.id) },
+      product: { key: String(data.id) },
+      authorName: data.displayed_name ?? data.user?.name ?? 'Anonymous',
+      authorId: data.user?.id != null ? String(data.user.id) : undefined,
+      rating: data.rating,
+      title: '',
+      content: data.text ?? data.translated_text ?? '',
+      reply:
+        typeof data.review_reply === 'string' ? data.review_reply : undefined,
+      repliedAt: undefined,
+      createdAt: data.created_at,
+      updatedAt: undefined,
+      verified: data.testimonial ?? false,
+    });
+  }
+
+  parseReviewPaginatedResult(
+    context: RequestContext,
+    data: LipscoreReviewsPage,
+  ): z.output<TReviewPaginatedSchema> {
+    const product = data.response[0];
+    const allReviews = product?.reviews ?? [];
+    const totalCount = allReviews.length;
+
+    const pageSize = data.pageSize > 0 ? data.pageSize : 10;
+    const pageNumber = data.pageNumber > 0 ? data.pageNumber : 1;
+    const totalPages = pageSize > 0 ? Math.ceil(totalCount / pageSize) : 1;
+
+    const offset = (pageNumber - 1) * pageSize;
+    const pageReviews = allReviews.slice(offset, offset + pageSize);
+
+    const items = pageReviews.map((r) => {
+      const parsed = this.parseReview(context, r);
+      return { ...parsed, product: { key: data.productKey } };
+    });
+
+    return this.reviewPaginatedSchema.parse({
+      items,
+      totalCount,
+      pageSize,
+      pageNumber,
+      totalPages,
+    });
+  }
+}

--- a/packages/lipscore/src/index.ts
+++ b/packages/lipscore/src/index.ts
@@ -1,0 +1,8 @@
+export * from './core/initialize.js';
+export * from './core/initialize.types.js';
+export * from './capabilities/index.js';
+export * from './factories/index.js';
+
+export * from './schema/configuration.schema.js';
+export * from './schema/capabilities.schema.js';
+export * from './schema/lipscore.schema.js';

--- a/packages/lipscore/src/schema/capabilities.schema.ts
+++ b/packages/lipscore/src/schema/capabilities.schema.ts
@@ -1,0 +1,55 @@
+import type {
+  Cache,
+  ProductReviewsCapability,
+  ProductReviewsFactory,
+  ProductReviewsFactoryWithOutput,
+  RequestContext,
+} from '@reactionary/core';
+import { CapabilitiesSchema } from '@reactionary/core';
+import type { LipscoreConfiguration } from './configuration.schema.js';
+import type { LipscoreClient } from '../core/client.js';
+import * as z from 'zod';
+
+const ProductReviewsCapabilitySchema = z.looseObject({
+  enabled: z.boolean(),
+  factory: z.unknown().optional(),
+  capability: z.unknown().optional(),
+});
+
+export const LipscoreCapabilitiesSchema = CapabilitiesSchema.pick({
+  productReviews: true,
+})
+  .extend({
+    productReviews: ProductReviewsCapabilitySchema.optional(),
+  })
+  .partial();
+
+export type LipscoreCapabilities = z.infer<typeof LipscoreCapabilitiesSchema>;
+
+// ---------------------------------------------------------------------------
+// Per-capability factory args and config types
+// ---------------------------------------------------------------------------
+
+export interface LipscoreCapabilityFactoryArgs {
+  cache: Cache;
+  context: RequestContext;
+  config: LipscoreConfiguration;
+}
+
+export interface LipscoreProductReviewsCapabilityFactoryArgs<
+  TFactory extends ProductReviewsFactory = ProductReviewsFactory,
+> extends LipscoreCapabilityFactoryArgs {
+  client: LipscoreClient;
+  factory: ProductReviewsFactoryWithOutput<TFactory>;
+}
+
+export interface LipscoreProductReviewsCapabilityConfig<
+  TFactory extends ProductReviewsFactory = ProductReviewsFactory,
+  TCapability extends ProductReviewsCapability = ProductReviewsCapability,
+> {
+  enabled: boolean;
+  factory?: ProductReviewsFactoryWithOutput<TFactory>;
+  capability?: (
+    args: LipscoreProductReviewsCapabilityFactoryArgs<TFactory>,
+  ) => TCapability;
+}

--- a/packages/lipscore/src/schema/configuration.schema.ts
+++ b/packages/lipscore/src/schema/configuration.schema.ts
@@ -1,0 +1,18 @@
+import * as z from 'zod';
+
+export const LipscoreConfigurationSchema = z.looseObject({
+  apiKey: z.string().meta({ description: 'Lipscore public API key.' }),
+  apiSecret: z
+    .string()
+    .optional()
+    .meta({
+      description:
+        'Lipscore server-side API secret. When set it is sent as the X-Authorization header.',
+    }),
+  apiUrl: z
+    .string()
+    .default('https://api.lipscore.com')
+    .meta({ description: 'Base Lipscore API URL.' }),
+});
+
+export type LipscoreConfiguration = z.infer<typeof LipscoreConfigurationSchema>;

--- a/packages/lipscore/src/schema/lipscore.schema.ts
+++ b/packages/lipscore/src/schema/lipscore.schema.ts
@@ -1,0 +1,65 @@
+import * as z from 'zod';
+
+// ---------------------------------------------------------------------------
+// User embedded in a review
+// ---------------------------------------------------------------------------
+
+const LipscoreReviewUserSchema = z.looseObject({
+  id: z.number().optional(),
+  name: z.string().optional(),
+  short_name: z.string().optional(),
+  email: z.string().optional(),
+});
+
+// ---------------------------------------------------------------------------
+// Image embedded in a review
+// ---------------------------------------------------------------------------
+
+const LipscoreReviewImageSchema = z.looseObject({
+  thumb_url: z.string().optional(),
+  image_url: z.string().optional(),
+});
+
+// ---------------------------------------------------------------------------
+// Individual review
+// ---------------------------------------------------------------------------
+
+export const LipscoreReviewSchema = z.looseObject({
+  id: z.number(),
+  text: z.string().optional(),
+  translated_text: z.string().optional(),
+  created_at: z.string(),
+  votes_up: z.number().optional(),
+  votes_down: z.number().optional(),
+  purchase_date: z.string().optional(),
+  rating: z.number(),
+  user: LipscoreReviewUserSchema.optional(),
+  images: z.array(LipscoreReviewImageSchema).optional(),
+  review_reply: z.unknown().optional(),
+  displayed_name: z.string().optional(),
+  testimonial: z.boolean().optional(),
+  attributes: z.array(z.unknown()).optional(),
+});
+
+export type LipscoreReview = z.infer<typeof LipscoreReviewSchema>;
+
+// ---------------------------------------------------------------------------
+// Product object returned by GET /products
+// ---------------------------------------------------------------------------
+
+export const LipscoreProductSchema = z.looseObject({
+  internal_id: z.union([z.string(), z.number()]).optional(),
+  reviews: z.array(LipscoreReviewSchema).default([]),
+});
+
+export type LipscoreProduct = z.infer<typeof LipscoreProductSchema>;
+
+// ---------------------------------------------------------------------------
+// Top-level response: array of products
+// ---------------------------------------------------------------------------
+
+export const LipscoreProductsResponseSchema = z.array(LipscoreProductSchema);
+
+export type LipscoreProductsResponse = z.infer<
+  typeof LipscoreProductsResponseSchema
+>;

--- a/packages/lipscore/src/test/product-reviews.capability.spec.ts
+++ b/packages/lipscore/src/test/product-reviews.capability.spec.ts
@@ -1,0 +1,142 @@
+// Lipscore REST API
+// Credentials: LIPSCORE_API_KEY (required), LIPSCORE_API_SECRET (optional)
+// Test product: set LIPSCORE_TEST_PRODUCT_ID to an internal_id that has reviews
+import 'dotenv/config';
+import { describe, expect, it, beforeEach, assert } from 'vitest';
+import { NoOpCache, createInitialRequestContext } from '@reactionary/core';
+import { LipscoreProductReviewsCapability } from '../capabilities/product-reviews.capability.js';
+import { LipscoreProductReviewsFactory } from '../factories/product-reviews/product-reviews.factory.js';
+import { LipscoreClient } from '../core/client.js';
+import {
+  ProductRatingSummarySchema,
+  ProductReviewSchema,
+  ProductReviewPaginatedResultSchema,
+} from '@reactionary/core';
+import type { LipscoreConfiguration } from '../schema/configuration.schema.js';
+
+const testData = {
+  productId: process.env['LIPSCORE_TEST_PRODUCT_ID'] ?? 'DR-CHRS-0001',
+};
+
+function getLipscoreTestConfiguration(): LipscoreConfiguration {
+  const apiKey = process.env['LIPSCORE_API_KEY'];
+  if (!apiKey) {
+    throw new Error(
+      'LIPSCORE_API_KEY environment variable is required for integration tests.',
+    );
+  }
+  return {
+    apiKey,
+    apiSecret: process.env['LIPSCORE_API_SECRET'],
+    apiUrl: process.env['LIPSCORE_API_URL'] ?? 'https://api.lipscore.com',
+  };
+}
+
+describe('LipscoreProductReviewsCapability', () => {
+  let provider: LipscoreProductReviewsCapability;
+
+  beforeEach(() => {
+    const config = getLipscoreTestConfiguration();
+    const reqCtx = createInitialRequestContext();
+    const client = new LipscoreClient(config, reqCtx);
+    provider = new LipscoreProductReviewsCapability(
+      new NoOpCache(),
+      reqCtx,
+      config,
+      client,
+      new LipscoreProductReviewsFactory(
+        ProductRatingSummarySchema,
+        ProductReviewSchema,
+        ProductReviewPaginatedResultSchema,
+      ),
+    );
+  });
+
+  it('getRatingSummary — returns a valid rating summary', async () => {
+    const result = await provider.getRatingSummary({
+      product: { key: testData.productId },
+    });
+
+    assert(result.success, `Expected success, got: ${JSON.stringify(result)}`);
+
+    if (
+      result.value.totalRatings !== undefined &&
+      result.value.totalRatings > 0
+    ) {
+      expect(result.value.averageRating).toBeGreaterThan(0);
+      expect(result.value.averageRating).toBeLessThanOrEqual(5);
+      expect(result.value.totalRatings).toBeGreaterThan(0);
+    } else {
+      expect(result.value.averageRating).toBe(0);
+      expect(result.value.totalRatings).toBeUndefined();
+    }
+  });
+
+  it('getRatingSummary — returns empty summary for unknown product', async () => {
+    const result = await provider.getRatingSummary({
+      product: { key: 'DOES-NOT-EXIST-XYZ-999999' },
+    });
+
+    assert(result.success, `Expected success, got: ${JSON.stringify(result)}`);
+    expect(result.value.averageRating).toBe(0);
+    expect(result.value.totalRatings).toBeUndefined();
+  });
+
+  it('findReviews — returns paginated review list', async () => {
+    const result = await provider.findReviews({
+      product: { key: testData.productId },
+      paginationOptions: { pageSize: 5, pageNumber: 1 },
+    });
+
+    assert(result.success, `Expected success, got: ${JSON.stringify(result)}`);
+
+    expect(Array.isArray(result.value.items)).toBe(true);
+    expect(result.value.items.length).toBeLessThanOrEqual(5);
+    expect(result.value.pageSize).toBe(5);
+    expect(result.value.pageNumber).toBe(1);
+    expect(result.value.totalPages).toBeGreaterThanOrEqual(0);
+
+    for (const review of result.value.items) {
+      expect(review.rating).toBeGreaterThanOrEqual(1);
+      expect(review.rating).toBeLessThanOrEqual(5);
+      expect(typeof review.title).toBe('string');
+      expect(typeof review.content).toBe('string');
+      expect(typeof review.createdAt).toBe('string');
+    }
+  });
+
+  it('findReviews — second page differs from first', async () => {
+    const page1 = await provider.findReviews({
+      product: { key: testData.productId },
+      paginationOptions: { pageSize: 2, pageNumber: 1 },
+    });
+    const page2 = await provider.findReviews({
+      product: { key: testData.productId },
+      paginationOptions: { pageSize: 2, pageNumber: 2 },
+    });
+
+    assert(page1.success, `Expected success, got: ${JSON.stringify(page1)}`);
+    assert(page2.success, `Expected success, got: ${JSON.stringify(page2)}`);
+
+    if (page1.value.totalPages > 1 && page2.value.items.length > 0) {
+      const page1Ids = page1.value.items.map((r) => r.identifier.key);
+      const page2Ids = page2.value.items.map((r) => r.identifier.key);
+      expect(page1Ids).not.toEqual(page2Ids);
+    }
+  });
+
+  it('submitReview — returns InvalidInput (widget-only)', async () => {
+    const result = await provider.submitReview({
+      product: { key: testData.productId },
+      rating: 4,
+      title: 'Great product',
+      content: 'Really enjoying it.',
+      authorName: 'Test User',
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.type).toBe('InvalidInput');
+    }
+  });
+});

--- a/packages/lipscore/tsconfig.json
+++ b/packages/lipscore/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "importHelpers": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/packages/lipscore/tsconfig.lib.json
+++ b/packages/lipscore/tsconfig.lib.json
@@ -1,0 +1,23 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": [
+    "vite.config.ts",
+    "vite.config.mts",
+    "vitest.config.ts",
+    "vitest.config.mts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.tsx",
+    "src/**/*.test.js",
+    "src/**/*.spec.js",
+    "src/**/*.test.jsx",
+    "src/**/*.spec.jsx"
+  ]
+}

--- a/packages/lipscore/tsconfig.spec.json
+++ b/packages/lipscore/tsconfig.spec.json
@@ -1,0 +1,28 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "types": [
+      "vitest/globals",
+      "vitest/importMeta",
+      "vite/client",
+      "node",
+      "vitest"
+    ]
+  },
+  "include": [
+    "vite.config.ts",
+    "vite.config.mts",
+    "vitest.config.ts",
+    "vitest.config.mts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.tsx",
+    "src/**/*.test.js",
+    "src/**/*.spec.js",
+    "src/**/*.test.jsx",
+    "src/**/*.spec.jsx",
+    "src/**/*.d.ts"
+  ]
+}

--- a/packages/lipscore/vite.config.ts
+++ b/packages/lipscore/vite.config.ts
@@ -1,0 +1,22 @@
+/// <reference types='vitest' />
+import { defineConfig } from 'vite';
+import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
+
+export default defineConfig(() => ({
+  root: import.meta.dirname,
+  cacheDir: '../../node_modules/.vite/packages/lipscore',
+  plugins: [nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
+  test: {
+    name: 'lipscore',
+    watch: false,
+    globals: true,
+    environment: 'node',
+    include: ['{src,tests}/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    reporters: ['default'],
+    coverage: {
+      reportsDirectory: '../../coverage/packages/lipscore',
+      provider: 'v8' as const,
+    },
+  },
+}));

--- a/packages/lipscore/vitest.config.mts
+++ b/packages/lipscore/vitest.config.mts
@@ -1,0 +1,21 @@
+import { defineConfig } from 'vitest/config';
+import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
+
+export default defineConfig(() => ({
+  root: __dirname,
+  cacheDir: '../../node_modules/.vite/packages/lipscore',
+  plugins: [nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
+  test: {
+    name: 'lipscore',
+    watch: false,
+    globals: true,
+    environment: 'node',
+    include: ['{src,tests}/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    reporters: ['default'],
+    coverage: {
+      reportsDirectory: '../../coverage/packages/lipscore',
+      provider: 'v8' as const,
+    },
+  },
+}));


### PR DESCRIPTION
… capability

Converts the ad-hoc Lipscore integration from karkkainen-commerce-storefront into a proper standalone provider package following the Bazaarvoice pattern.