### PR TITLE
feat(lipscore): add @reactionary/lipscore package with v2 API

### DIFF
--- a/packages/lipscore/src/capabilities/product-reviews.capability.ts
+++ b/packages/lipscore/src/capabilities/product-reviews.capability.ts
@@ -19,7 +19,11 @@ import {
   type RequestContext,
   type Result,
 } from '@reactionary/core';
-import { LipscoreProductsResponseSchema } from '../schema/lipscore.schema.js';
+import {
+  LipscoreProductsListSchema,
+  LipscoreReviewsResponseSchema,
+} from '../schema/lipscore.schema.js';
+import type { LipscoreProductListItem } from '../schema/lipscore.schema.js';
 import type { LipscoreConfiguration } from '../schema/configuration.schema.js';
 import type { LipscoreClient } from '../core/client.js';
 import type { LipscoreProductReviewsFactory } from '../factories/product-reviews/product-reviews.factory.js';
@@ -51,13 +55,15 @@ export class LipscoreProductReviewsCapability<
   public override async getRatingSummary(
     query: ProductReviewsGetRatingSummaryQuery,
   ): Promise<Result<ProductReviewsFactoryRatingOutput<TFactory>>> {
-    const response = await this.client.callGet(
-      this.getReviewsUrl(),
-      this.getRatingSummaryParams(query.product.key),
-      LipscoreProductsResponseSchema,
-    );
+    const product = await this.getProduct(query.product.key);
 
-    return success(this.factory.parseRatingSummary(this.context, response));
+    return success(
+      this.factory.parseRatingSummary(this.context, {
+        productKey: query.product.key,
+        votes: product?.votes ?? null,
+        rating: product?.rating ?? null,
+      }),
+    );
   }
 
   @Reactionary({
@@ -73,18 +79,33 @@ export class LipscoreProductReviewsCapability<
     const pageSize = query.paginationOptions?.pageSize ?? 10;
     const pageNumber = query.paginationOptions?.pageNumber ?? 1;
 
-    const response = await this.client.callGet(
-      this.getReviewsUrl(),
-      this.getReviewsParams(query.product.key),
-      LipscoreProductsResponseSchema,
+    const product = await this.getProduct(query.product.key);
+
+    if (product === null) {
+      return success(
+        this.factory.parseReviewPaginatedResult(this.context, {
+          reviews: [],
+          productKey: query.product.key,
+          pageSize,
+          pageNumber,
+          totalReviewCount: 0,
+        }),
+      );
+    }
+
+    const reviews = await this.client.callGet(
+      this.getReviewsUrl(product.id),
+      this.getReviewsParams(pageSize, pageNumber),
+      LipscoreReviewsResponseSchema,
     );
 
     return success(
       this.factory.parseReviewPaginatedResult(this.context, {
-        response,
+        reviews,
         productKey: query.product.key,
         pageSize,
         pageNumber,
+        totalReviewCount: product.review_count ?? undefined,
       }),
     );
   }
@@ -111,18 +132,24 @@ export class LipscoreProductReviewsCapability<
   // Extension points — override in subclasses to customise API calls
   // ---------------------------------------------------------------------------
 
-  protected getReviewsUrl(): string {
-    return `${this.client.baseUrl}/products`;
+  protected async getProduct(productKey: string): Promise<LipscoreProductListItem | null> {
+    const params = new URLSearchParams({ internal_id: productKey });
+    const products = await this.client.callGet(
+      `${this.client.baseUrl}/products`,
+      params,
+      LipscoreProductsListSchema,
+    );
+    return products[0] ?? null;
   }
 
-  protected getReviewsParams(productId: string): URLSearchParams {
+  protected getReviewsUrl(lipscoreProductId: number): string {
+    return `${this.client.baseUrl}/products/${lipscoreProductId}/reviews`;
+  }
+
+  protected getReviewsParams(pageSize: number, pageNumber: number): URLSearchParams {
     const params = new URLSearchParams();
-    params.set('internal_id[]', productId);
-    params.set('fields', 'reviews');
+    params.set('page', String(pageNumber));
+    params.set('per_page', String(pageSize));
     return params;
-  }
-
-  protected getRatingSummaryParams(productId: string): URLSearchParams {
-    return this.getReviewsParams(productId);
   }
 }

--- a/packages/lipscore/src/capabilities/product-reviews.capability.ts
+++ b/packages/lipscore/src/capabilities/product-reviews.capability.ts
@@ -132,21 +132,33 @@ export class LipscoreProductReviewsCapability<
   // Extension points — override in subclasses to customise API calls
   // ---------------------------------------------------------------------------
 
-  protected async getProduct(productKey: string): Promise<LipscoreProductListItem | null> {
-    const params = new URLSearchParams({ internal_id: productKey });
+  protected async getProduct(
+    productKey: string,
+  ): Promise<LipscoreProductListItem | null> {
+    const params = this.getProductsParams(productKey);
     const products = await this.client.callGet(
-      `${this.client.baseUrl}/products`,
+      this.getProductsUrl(),
       params,
       LipscoreProductsListSchema,
     );
     return products[0] ?? null;
   }
-
+  protected getProductsUrl(): string {
+    return `${this.client.baseUrl}/products`;
+  }
   protected getReviewsUrl(lipscoreProductId: number): string {
     return `${this.client.baseUrl}/products/${lipscoreProductId}/reviews`;
   }
-
-  protected getReviewsParams(pageSize: number, pageNumber: number): URLSearchParams {
+  protected getProductsParams(productKey: string): URLSearchParams {
+    const params = new URLSearchParams();
+    params.set('internal_id', productKey);
+    params.set('fields', 'rating,review_count');
+    return params;
+  }
+  protected getReviewsParams(
+    pageSize: number,
+    pageNumber: number,
+  ): URLSearchParams {
     const params = new URLSearchParams();
     params.set('page', String(pageNumber));
     params.set('per_page', String(pageSize));

--- a/packages/lipscore/src/factories/product-reviews/product-reviews.factory.ts
+++ b/packages/lipscore/src/factories/product-reviews/product-reviews.factory.ts
@@ -9,16 +9,20 @@ import type {
   ProductReviewSchema,
   ProductReviewPaginatedResultSchema,
 } from '@reactionary/core';
-import type {
-  LipscoreReview,
-  LipscoreProductsResponse,
-} from '../../schema/lipscore.schema.js';
+import type { LipscoreReview } from '../../schema/lipscore.schema.js';
+
+export interface LipscoreRatingSummaryData {
+  productKey: string;
+  votes: number | null;
+  rating: string | null;
+}
 
 export interface LipscoreReviewsPage {
-  response: LipscoreProductsResponse;
+  reviews: LipscoreReview[];
   productKey: string;
   pageSize: number;
   pageNumber: number;
+  totalReviewCount?: number;
 }
 
 export class LipscoreProductReviewsFactory<
@@ -42,41 +46,19 @@ export class LipscoreProductReviewsFactory<
 
   parseRatingSummary(
     _context: RequestContext,
-    data: LipscoreProductsResponse,
+    data: LipscoreRatingSummaryData,
   ): z.output<TRatingSummarySchema> {
-    const product = data[0];
-    const reviews = product?.reviews ?? [];
-
-    if (reviews.length === 0) {
-      return this.ratingSummarySchema.parse({
-        identifier: { product: { key: String(product?.internal_id ?? '') } },
-        averageRating: 0,
-        totalRatings: undefined,
-        ratingDistribution: undefined,
-      });
-    }
-
-    const total = reviews.length;
-    const sum = reviews.reduce((acc, r) => acc + r.rating, 0);
-    const averageRating = Math.round((sum / total) * 100) / 100;
-
-    const distribution: Record<string, number> = {
-      '1': 0,
-      '2': 0,
-      '3': 0,
-      '4': 0,
-      '5': 0,
-    };
-    for (const review of reviews) {
-      const key = String(Math.min(5, Math.max(1, Math.round(review.rating))));
-      distribution[key] = (distribution[key] ?? 0) + 1;
-    }
+    const votes = data.votes ?? 0;
+    const averageRating =
+      votes > 0 && data.rating
+        ? Math.round(parseFloat(data.rating) * 100) / 100
+        : 0;
 
     return this.ratingSummarySchema.parse({
-      identifier: { product: { key: String(product?.internal_id ?? '') } },
+      identifier: { product: { key: data.productKey } },
       averageRating,
-      totalRatings: total,
-      ratingDistribution: distribution,
+      totalRatings: votes > 0 ? votes : undefined,
+      ratingDistribution: undefined,
     });
   }
 
@@ -86,18 +68,22 @@ export class LipscoreProductReviewsFactory<
   ): z.output<TReviewSchema> {
     return this.reviewSchema.parse({
       identifier: { key: String(data.id) },
-      product: { key: String(data.id) },
-      authorName: data.displayed_name ?? data.user?.name ?? 'Anonymous',
+      product: { key: data.product?.internal_id ?? String(data.id) },
+      authorName:
+        data.displayed_name ??
+        data.user?.short_name ??
+        data.user?.name ??
+        'Anonymous',
       authorId: data.user?.id != null ? String(data.user.id) : undefined,
       rating: data.rating,
       title: '',
       content: data.text ?? data.translated_text ?? '',
-      reply:
-        typeof data.review_reply === 'string' ? data.review_reply : undefined,
-      repliedAt: undefined,
+      reply: data.review_reply != null ? (data.review_reply.text ?? undefined) : undefined,
+      repliedAt:
+        data.review_reply != null ? (data.review_reply.created_at ?? undefined) : undefined,
       createdAt: data.created_at,
       updatedAt: undefined,
-      verified: data.testimonial ?? false,
+      verified: false,
     });
   }
 
@@ -105,18 +91,21 @@ export class LipscoreProductReviewsFactory<
     context: RequestContext,
     data: LipscoreReviewsPage,
   ): z.output<TReviewPaginatedSchema> {
-    const product = data.response[0];
-    const allReviews = product?.reviews ?? [];
-    const totalCount = allReviews.length;
-
     const pageSize = data.pageSize > 0 ? data.pageSize : 10;
     const pageNumber = data.pageNumber > 0 ? data.pageNumber : 1;
+
+    // Use API-provided review_count when available for accurate pagination.
+    // Fall back to deriving from page data when not available.
+    const totalCount =
+      data.totalReviewCount !== undefined
+        ? data.totalReviewCount
+        : data.reviews.length < pageSize
+          ? (pageNumber - 1) * pageSize + data.reviews.length
+          : pageNumber * pageSize + 1;
+
     const totalPages = pageSize > 0 ? Math.ceil(totalCount / pageSize) : 1;
 
-    const offset = (pageNumber - 1) * pageSize;
-    const pageReviews = allReviews.slice(offset, offset + pageSize);
-
-    const items = pageReviews.map((r) => {
+    const items = data.reviews.map((r) => {
       const parsed = this.parseReview(context, r);
       return { ...parsed, product: { key: data.productKey } };
     });

--- a/packages/lipscore/src/schema/configuration.schema.ts
+++ b/packages/lipscore/src/schema/configuration.schema.ts
@@ -4,10 +4,9 @@ export const LipscoreConfigurationSchema = z.looseObject({
   apiKey: z.string().meta({ description: 'Lipscore public API key.' }),
   apiSecret: z
     .string()
-    .optional()
     .meta({
       description:
-        'Lipscore server-side API secret. When set it is sent as the X-Authorization header.',
+        'Lipscore server-side API secret. Sent as the X-Authorization header on all v2 API requests.',
     }),
   apiUrl: z
     .string()

--- a/packages/lipscore/src/schema/lipscore.schema.ts
+++ b/packages/lipscore/src/schema/lipscore.schema.ts
@@ -1,65 +1,89 @@
 import * as z from 'zod';
 
-// ---------------------------------------------------------------------------
-// User embedded in a review
-// ---------------------------------------------------------------------------
-
-const LipscoreReviewUserSchema = z.looseObject({
+const LipscoreUserSchema = z.looseObject({
   id: z.number().optional(),
   name: z.string().optional(),
   short_name: z.string().optional(),
   email: z.string().optional(),
 });
 
-// ---------------------------------------------------------------------------
-// Image embedded in a review
-// ---------------------------------------------------------------------------
+const LipscoreProductEmbedSchema = z.looseObject({
+  name: z.string().nullable().optional(),
+  gtin: z.string().nullable().optional(),
+  sku: z.string().nullable().optional(),
+  variant_id: z.string().nullable().optional(),
+  mpn: z.string().nullable().optional(),
+  internal_id: z.string().nullable().optional(),
+});
+
+// Items from GET /products/{id}/ratings — rating is 1–5 directly
+export const LipscoreRatingSchema = z.looseObject({
+  id: z.number(),
+  created_at: z.string(),
+  updated_at: z.string().optional(),
+  status: z.string().nullable().optional(),
+  lang: z.string().optional(),
+  origin: z.string().optional(),
+  rating: z.number(),
+  user: LipscoreUserSchema.optional(),
+  product: LipscoreProductEmbedSchema.optional(),
+  internal_order_id: z.string().nullable().optional(),
+  internal_customer_id: z.string().nullable().optional(),
+});
+
+export type LipscoreRating = z.infer<typeof LipscoreRatingSchema>;
+
+export const LipscoreRatingsResponseSchema = z.array(LipscoreRatingSchema);
+export type LipscoreRatingsResponse = z.infer<typeof LipscoreRatingsResponseSchema>;
 
 const LipscoreReviewImageSchema = z.looseObject({
+  id: z.number().optional(),
   thumb_url: z.string().optional(),
   image_url: z.string().optional(),
 });
 
-// ---------------------------------------------------------------------------
-// Individual review
-// ---------------------------------------------------------------------------
+const LipscoreReviewReplySchema = z.looseObject({
+  text: z.string().optional(),
+  created_at: z.string().optional(),
+  translated_text: z.string().nullable().optional(),
+  member_site: z.string().optional(),
+  lang: z.string().optional(),
+});
 
+// Items from GET /products/{id}/reviews — rating is 1–5 directly
 export const LipscoreReviewSchema = z.looseObject({
   id: z.number(),
-  text: z.string().optional(),
-  translated_text: z.string().optional(),
+  text: z.string().nullable().optional(),
+  translated_text: z.string().nullable().optional(),
   created_at: z.string(),
   votes_up: z.number().optional(),
   votes_down: z.number().optional(),
-  purchase_date: z.string().optional(),
+  purchase_date: z.string().nullable().optional(),
   rating: z.number(),
-  user: LipscoreReviewUserSchema.optional(),
+  user: LipscoreUserSchema.optional(),
   images: z.array(LipscoreReviewImageSchema).optional(),
-  review_reply: z.unknown().optional(),
-  displayed_name: z.string().optional(),
+  review_reply: z.union([LipscoreReviewReplySchema, z.null()]).optional(),
   testimonial: z.boolean().optional(),
+  displayed_name: z.string().nullable().optional(),
+  imported_at: z.string().optional(),
+  product: LipscoreProductEmbedSchema.optional(),
   attributes: z.array(z.unknown()).optional(),
 });
 
 export type LipscoreReview = z.infer<typeof LipscoreReviewSchema>;
 
-// ---------------------------------------------------------------------------
-// Product object returned by GET /products
-// ---------------------------------------------------------------------------
+export const LipscoreReviewsResponseSchema = z.array(LipscoreReviewSchema);
+export type LipscoreReviewsResponse = z.infer<typeof LipscoreReviewsResponseSchema>;
 
-export const LipscoreProductSchema = z.looseObject({
-  internal_id: z.union([z.string(), z.number()]).optional(),
+// Shape for GET /products?internal_id={x}
+export const LipscoreProductListItemSchema = z.looseObject({
+  id: z.number(),
+  internal_id: z.string().optional(),
+  votes: z.number().nullable().optional(),
+  rating: z.string().nullable().optional(),
+  review_count: z.number().nullable().optional(),
   reviews: z.array(LipscoreReviewSchema).default([]),
 });
 
-export type LipscoreProduct = z.infer<typeof LipscoreProductSchema>;
-
-// ---------------------------------------------------------------------------
-// Top-level response: array of products
-// ---------------------------------------------------------------------------
-
-export const LipscoreProductsResponseSchema = z.array(LipscoreProductSchema);
-
-export type LipscoreProductsResponse = z.infer<
-  typeof LipscoreProductsResponseSchema
->;
+export const LipscoreProductsListSchema = z.array(LipscoreProductListItemSchema);
+export type LipscoreProductListItem = z.infer<typeof LipscoreProductListItemSchema>;

--- a/packages/lipscore/src/test/product-reviews.capability.spec.ts
+++ b/packages/lipscore/src/test/product-reviews.capability.spec.ts
@@ -25,9 +25,15 @@ function getLipscoreTestConfiguration(): LipscoreConfiguration {
       'LIPSCORE_API_KEY environment variable is required for integration tests.',
     );
   }
+  const apiSecret = process.env['LIPSCORE_API_SECRET'];
+  if (!apiSecret) {
+    throw new Error(
+      'LIPSCORE_API_SECRET environment variable is required for integration tests.',
+    );
+  }
   return {
     apiKey,
-    apiSecret: process.env['LIPSCORE_API_SECRET'],
+    apiSecret,
     apiUrl: process.env['LIPSCORE_API_URL'] ?? 'https://api.lipscore.com',
   };
 }


### PR DESCRIPTION
## Summary

- Adds new `@reactionary/lipscore` package implementing `ProductReviewsCapability` for the [Lipscore](https://lipscore.com) product review platform
- Uses the Lipscore v2 REST API (`api.lipscore.com`) with proper auth (`api_key` query param + `X-Authorization` header)
- Products are resolved by store `internal_id` via `GET /products?internal_id={key}`, which also provides `votes`, `rating`, and `review_count` for the rating summary — no separate ratings endpoint needed
- Paginated reviews fetched from `GET /products/{id}/reviews?page={p}&per_page={n}` with accurate `totalPages` from `review_count`
- Rating scale is 1–5 directly in v2 (no conversion)
- `submitReview` returns `InvalidInput` — Lipscore handles submission via widget only

## Test plan

- [ ] Set `LIPSCORE_API_KEY`, `LIPSCORE_API_SECRET`, `LIPSCORE_TEST_PRODUCT_ID` in `.env`
- [ ] `source .env && npx vitest run --config packages/lipscore/vitest.config.mts` — all 5 integration tests pass
- [ ] `npx nx build lipscore` — builds cleanly
- [ ] `npx nx lint lipscore` — no lint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)